### PR TITLE
Update mvm_underworld_rc2_int_astral_projection.pop

### DIFF
--- a/scripts/population/mvm_underworld_rc2_int_astral_projection.pop
+++ b/scripts/population/mvm_underworld_rc2_int_astral_projection.pop
@@ -1905,7 +1905,7 @@ WaveSchedule
 		{
 			Name				stage2
 			WaitForAllSpawned	stage1
-			Where				spawnbot
+			Where			spawnbot_side	// spawnbot
 			TotalCount			16	// 32
 			MaxActive			6	// 12
 			SpawnCount			2	// 4


### PR DESCRIPTION
Tweak w5; steels spawn from side instead of main, giving them time to drop down and cool off their cooldown & shoot initial fireball, they do nothing with current version if you fronthold.