### PR TITLE
Undead Dread update 1

### DIFF
--- a/scripts/population/mvm_underworld_rc2_adv_undead_dread.pop
+++ b/scripts/population/mvm_underworld_rc2_adv_undead_dread.pop
@@ -27,54 +27,7 @@ WaveSchedule
 	
 	PrecacheSound "sfx_supermove.wav"
 	
-	UpgradeStationKeepWeapons 1  
-	
-	// judging v
-	
-	// ItemBlacklist  
-	// {
-		// SimilarToItem "The Phlogistinator"
-		// SimilarToItem "The Ubersaw"
-	// }
-	
-	// DisallowUpgrade	"applies snare effect"  
-	// DisallowUpgrade	"ubercharge"  
-	// DisallowUpgrade	"critboost"  
-	// DisallowUpgrade	"mad milk syringes"  
-	// DisallowUpgrade	"generate rage on heal"  
-	// DisallowUpgrade	"uber duration bonus" 
-	// DisallowUpgrade  
-	// {
-		// Upgrade "effect bar recharge rate increased"
-		// ClassName "tf_weapon_jar"
-		// ClassName "tf_weapon_jar_milk"
-	// }
-	// DisallowUpgrade	  
-	// {
-		// Upgrade "explosive sniper shot"
-		// ClassName "tf_weapon_sniperrifle"
-		// ClassName "tf_weapon_sniperrifle_decap"
-	// }
-	// DisallowUpgrade	  
-	// {
-		// Upgrade "rocket specialist"
-		// SimilarToItem "The Beggar's Bazooka"
-	// }
-	
-	// judging ^
-	
-	// extra unofficial restrictions v
-	
-	// MaxRedPlayers 5
-	
-	// ClassLimit
-	// {
-		// Spy 0
-	// }
-	
-	// DisallowUpgrade "airblast pushback scale"
-	
-	// extra unofficial restrictions ^
+	UpgradeStationKeepWeapons 1 [$SIGSEGV]
 	
 	Mission
 	{
@@ -618,7 +571,7 @@ WaveSchedule
 			TotalCount 16
 			WaitForAllSpawned "W1D-2"
 			WaitBeforeStarting 10
-			WaitBetweenSpawns 2.5
+			WaitBetweenSpawns 2.25
 			TotalCurrency 50
 			Support 1
 			TFBot
@@ -1017,11 +970,6 @@ WaveSchedule
 				}
 			}
 		}
-		WaveSpawn
-		{
-			Support 1
-			TFBot { ClassIcon dead_blu_lite }
-		}
 	}
 	Wave // WAVE 3
 	{
@@ -1130,7 +1078,7 @@ WaveSchedule
 			TotalCount 24
 			WaitForAllDead "W3B-2"
 			WaitBeforeStarting 0
-			WaitBetweenSpawns 8
+			WaitBetweenSpawns 7
 			Support 1
 			TotalCurrency 50
 			FirstSpawnOutput
@@ -1190,12 +1138,12 @@ WaveSchedule
 				TFBot
 				{
 					Class Heavyweapons
-					Skill Normal
+					Skill Hard
 				}
 				TFBot
 				{
 					Class Heavyweapons
-					Skill Normal
+					Skill Hard
 				}
 			}
 		}
@@ -1209,7 +1157,7 @@ WaveSchedule
 			TotalCount 21
 			WaitForAllDead "W3B-2"
 			WaitBeforeStarting 35
-			WaitBetweenSpawns 10
+			WaitBetweenSpawns 9
 			Support 1
 			TotalCurrency 50
 			FirstSpawnOutput
@@ -1464,11 +1412,6 @@ WaveSchedule
 					Template T_TFBot_Giant_Medic_Shotgun
 				}
 			}
-		}
-		WaveSpawn
-		{
-			Support 1
-			TFBot { ClassIcon dead_blu_lite }
 		}
 	}
 	Wave // WAVE 4
@@ -1741,7 +1684,7 @@ WaveSchedule
 			MaxActive 2
 			TotalCount 2
 			WaitForAllSpawned "W4C-2"
-			WaitBeforeStarting 40
+			WaitBeforeStarting 30
 			WaitBetweenSpawns 0
 			TotalCurrency 50
 			DoneOutput
@@ -1885,11 +1828,6 @@ WaveSchedule
 				Attributes AlwaysCrit
 			}
 		}
-		WaveSpawn
-		{
-			Support 1
-			TFBot { ClassIcon dead_blu_lite }
-		}
 	}
 	Wave // BONUS SECRET WAVE
 	{
@@ -1943,6 +1881,7 @@ WaveSchedule
 					"override footstep sound set" 2
 					"airblast vertical vulnerability multiplier" 0.1
 					"rage giving scale" 0.1
+					"cannot be sapped" 1
 				}
 				
 				Tag hatch_snatcher
@@ -2292,6 +2231,7 @@ WaveSchedule
 			WaitForAllDead "W5B-2"
 			WaitBeforeStarting 45
 			WaitBetweenSpawns 10
+			Support Limited
 			TotalCurrency 100
 			TFBot
 			{
@@ -2426,17 +2366,79 @@ WaveSchedule
 		// Checkpoint Yes
 		// WaveSpawn
 		// {
+			// Name "W4F"
 			// Where spawnbot
-			// SpawnCount 1
-			// MaxActive 1
+			// SpawnCount 5
+			// MaxActive 5
 			// TotalCount 300
+			// WaitBeforeStarting 1
+			// WaitBetweenSpawns 0
+			// TotalCurrency 0
+			// Squad
+			// {
+				// TFBot
+				// {
+					// Class Scout
+					// Tag test
+				// }
+				// TFBot
+				// {
+					// Class Soldier
+					// Tag test
+				// }
+				// TFBot
+				// {
+					// Class Pyro
+					// Tag test
+				// }
+				// TFBot
+				// {
+					// Class Demoman
+					// Tag test
+				// }
+				// TFBot
+				// {
+					// Class Heavyweapons
+					// Tag test
+				// }
+			// }
+		// }
+		// WaveSpawn
+		// {
+			// Name "W4-Support"
+			// Where spawnbot_samurai
+			// SpawnCount 3
+			// MaxActive 21
+			// TotalCount 21
 			// WaitBeforeStarting 0
-			// WaitBetweenSpawns 3600
+			// WaitBetweenSpawns 0.5
+			// Support 1
 			// TotalCurrency 0
 			// TFBot
 			// {
-				// Template T_TFBot_Sniper_Huntsman_Stun
-				// Tag test
+				// Template T_TFBot_Soldier_Samurai
+				// Tag samurai_minion
+				// ClassIcon noicon
+				// Attributes AlwaysCrit
+			// }
+		// }
+		// WaveSpawn
+		// {
+			// Name "W4-Support"
+			// Where spawnbot_samurai_2
+			// SpawnCount 2
+			// MaxActive 20
+			// TotalCount 20
+			// WaitBeforeStarting 0
+			// WaitBetweenSpawns 0.5
+			// Support 1
+			// TotalCurrency 0
+			// TFBot
+			// {
+				// Template T_TFBot_Soldier_Samurai
+				// Tag samurai_minion
+				// ClassIcon noicon
+				// Attributes AlwaysCrit
 			// }
 		// }
 	// }

--- a/scripts/vscripts/pea2.nut
+++ b/scripts/vscripts/pea2.nut
@@ -1,36 +1,39 @@
 ::PEA_GLOBAL <-
 {
 	debug = ("debug" in PEA) ? PEA.debug : false
-
+	
 	sigmod = Convars.GetInt("sig_color_console") != null ? true : false
-
+	
 	countdown_skipped = false
-
+	
 	strip_romevision_items = false
-
+	
 	thinkertick = 1
-
+	
 	mission = NetProps.GetPropString(Entities.FindByClassname(null, "tf_objective_resource"), "m_iszMvMPopfileName")
-
+	
 	Wave = NetProps.GetPropInt(Entities.FindByClassname(null, "tf_objective_resource"), "m_nMannVsMachineWaveCount")
-
+	
 	moneydrop = Vector()
-
+	
 	customfuncs =
 	[
+		["CBaseCombatWeapon", ["GetOwner"]],
 		["CBaseEntity", ["Enable", "Disable"]],
-		["CTFPlayer", ["IsGrounded", "GetWeapon", "GetWearable"]],
-		["CTFBot", ["IsGrounded", "GetWeapon", "GetWearable", "Zombify"]]
+		["CTFBot", ["IsGrounded", "GetWeapon", "GetWearable", "GetWearableItem", "Zombify"]],
+		["CTFPlayer", ["IsGrounded", "GetWeapon", "GetWearable", "GetWearableItem"]]
 	]
-
+	
+	zombieitems = [5617, 5625, 5618, 5620, 5622, 5619, 5624, 5623, 5621]
+	
 	playerlog_limit = 16250
 	// playerlog_limit = 40
-
+	
 	tanks_in_wave = 0
 	blimps_in_wave = 0
-
+	
 	class_integers = ["", "scout", "sniper", "soldier", "demo", "medic", "heavy", "pyro", "spy", "engineer", "civilian"]
-
+	
 	ignite_player = Entities.CreateByClassname("tf_weapon_flamethrower")
 
 	GLOBAL_CALLBACKS =
@@ -40,7 +43,7 @@
 			foreach (player in GetAllPlayers(false, false, false))
 			{
 				player.ValidateScriptScope()
-
+				
 				if (player.IsFakeClient())
 				{
 					if (!sigmod)
@@ -49,44 +52,44 @@
 						NetProps.SetPropInt(player, "m_nForcedSkin", 0)
 						NetProps.SetPropInt(player, "m_iPlayerSkinOverride", 0)
 					}
-
+					
 					local scope = player.GetScriptScope()
 
 					NetProps.SetPropString(player, "m_iszScriptThinkFunction", "")
-
+					
 					for (local child = player.FirstMoveChild(); child != null; child = child.NextMovePeer())
-					{
+					{ 
 						if ("custom_wearable" in child.GetScriptScope()) { EntFireByHandle(child, "Kill", null, -1.0, null, null); continue }
-
+						
 						child.DisableDraw()
-
+						
 						continue
 					}
-
+					
 					foreach (thing in player.GetScriptScope())
 					{
 						try { thing.GetClassname() }
 						catch (e) { continue }
-
+						
 						if (!thing.IsPlayer()) thing.Kill()
 					}
-
+				
 					player.TerminateScriptScope()
 				}
 			}
-
+			
 			if (GetRoundState() == 3 && NetProps.GetPropString(objective_resource_entity, "m_iszMvMPopfileName") != mission)
 			{
 				if ("MapCleanup" in PEA) ::MapCleanup()
-
+				
 				for (local ent; ent = Entities.FindByClassname(ent, "entity_sign"); ) ent.Kill()
-
+				
 				foreach (entgroup in customfuncs) { foreach (func in entgroup[1]) getroottable()[entgroup[0]][func] <- function() {} }
 
 				foreach (thing, var in PEA) if (thing in getroottable()) delete getroottable()[thing]
-
+				
 				if ("PEA_ONETIME" in getroottable()) { foreach (thing, var in PEA_ONETIME) if (thing in getroottable()) delete getroottable()[thing] }
-
+				
 				for (local i = 1; i <= Constants.Server.MAX_PLAYERS; i++)
 				{
 					local player = PlayerInstanceFromIndex(i)
@@ -97,22 +100,22 @@
 						{
 							try { thing.GetClassname() }
 							catch (e) { continue }
-
+							
 							if (!thing.IsPlayer()) thing.Kill()
 						}
 					}
 
 					player.TerminateScriptScope()
 				}
-
+				
 				delete ::PEA
 				delete ::PEA_GLOBAL_ONETIME
-
+				
 				if ("PEA_ONETIME" in getroottable()) delete ::PEA_ONETIME
-
+				
 				return
 			}
-
+			
 			if (strip_romevision_items)
 			{
 				for (local ent; ent = Entities.FindByModel(ent, "models/bots/boss_bot/carrier.mdl"); )
@@ -122,7 +125,7 @@
 					NetProps.SetPropIntArray(ent, "m_nModelIndexOverrides", PrecacheModel("models/bots/boss_bot/carrier.mdl"), 2)
 					NetProps.SetPropIntArray(ent, "m_nModelIndexOverrides", PrecacheModel("models/bots/boss_bot/carrier.mdl"), 3)
 				}
-
+				
 				for (local ent; ent = Entities.FindByModel(ent, "models/bots/boss_bot/carrier_parts.mdl"); )
 				{
 					NetProps.SetPropIntArray(ent, "m_nModelIndexOverrides", PrecacheModel("models/bots/boss_bot/carrier_parts.mdl"), 0)
@@ -132,38 +135,38 @@
 				}
 			}
 		}
-
+		
 		OnGameEvent_player_spawn = function(params)
 		{
 			local bot = GetPlayerFromUserID(params.userid)
-
+			
 			if (!bot.IsFakeClient()) return
-
+			
 			EntFireByHandle(bot, "CallScriptFunction", "GlobalBotTagCheck", -1.0, null, null)
 		}
-
+		
 		OnGameEvent_player_death = function(params)
 		{
 			local dead_player = GetPlayerFromUserID(params.userid)
-
+			
 			if (dead_player.IsFakeClient())
-			{
+			{	
 				for (local cash; cash = Entities.FindByClassname(cash, "item_currencypack_custom"); ) AddThinkToEnt(cash, "ImprovedCashCollection_Think")
-
+				
 				local projectiles_leftbehind = false
-
+				
 				for (local ent; ent = Entities.FindByClassname(ent, "tf_projectile_*"); )
 				{
 					if (ent.GetOwner() == dead_player || NetProps.GetPropEntity(ent, "m_hThrower") == dead_player) { projectiles_leftbehind = true; break }
 				}
-
+				
 				EntFireByHandle(dead_player, "RunScriptCode", "self.SetUseBossHealthBar(false)", -1.0, null, null)
 
 				for (local child = dead_player.FirstMoveChild(); child != null; child = child.NextMovePeer())
 				{
-					if (child.GetClassname() == "tf_wearable" && child.GetScriptScope() != null) EntFireByHandle(child, "Kill", null, -1.0, null, null)
+					if (child.GetClassname() == "tf_wearable" && child.GetScriptScope() != null) EntFireByHandle(child, "Kill", null, 0.1, null, null) // needs extra delay to allow wearables to remain on ragdolls
 				}
-
+			
 				foreach (thing in dead_player.GetScriptScope())
 				{
 					try { thing.GetClassname() }
@@ -173,21 +176,21 @@
 				}
 
 				if (!projectiles_leftbehind) EntFireByHandle(dead_player, "RunScriptCode", "self.ForceChangeTeam(1, true)", 0.1, null, null)
-
+				
 				NetProps.SetPropString(dead_player, "m_iszScriptThinkFunction", "")
 				dead_player.TerminateScriptScope()
 			}
 		}
-
+		
 		OnGameEvent_mvm_begin_wave = function(params)
 		{
 			if (firstload) NetProps.SetPropFloat(gamerules_entity, "m_flRestartRoundTime", Time())
-
+			
 			HideIcon("noicon")
-
+			
 			if (WaveHasIcon("blimp2_lite")) UnhideIcon("blimp2_lite", 8)
 		}
-
+		
 		OnGameEvent_mvm_wave_complete = function(params) { wavewon = true }
 	}
 
@@ -197,7 +200,7 @@
 	ShovePlayer = function(player, radius)
 	{
 		local vradius = Vector(radius, radius, radius)
-
+		
 		local selfmins = self.GetBoundingMins() + self.GetOrigin() - vradius
 		local selfmaxs = self.GetBoundingMaxs() + self.GetOrigin() + vradius
 
@@ -212,13 +215,13 @@
 		pushforce = pushforce * 270
 
 		if (player.IsGrounded()) player.SetOrigin(player.GetOrigin() + Vector(0, 0, 24))
-
+		
 		player.RemoveFlag(1)
 		player.AddCond(115)
 
 		player.ApplyAbsVelocityImpulse(pushforce)
 	}
-
+	
 	PrecacheArray = function(array)
 	{
 		foreach (thing in array)
@@ -227,59 +230,59 @@
 			else PrecacheSound(thing)
 		}
 	}
-
+	
 	VectorAngles = function(forward)
 	{
 		local yaw, pitch;
-
+		
 		if (forward.y == 0.0 && forward.x == 0.0)
 		{
 			yaw = 0.0
-
+			
 			if (forward.z > 0.0) pitch = 270.0
 			else				 pitch = 90.0
 		}
-
+		
 		else
 		{
 			yaw = (atan2(forward.y, forward.x) * 180.0 / Constants.Math.Pi)
 			if (yaw < 0.0) yaw += 360.0
-
+	
 			pitch = (atan2(-forward.z, forward.Length2D()) * 180.0 / Constants.Math.Pi)
 			if (pitch < 0.0) pitch += 360.0
 		}
 
 		return QAngle(pitch, yaw, 0.0);
 	}
-
+	
 	GetAllPlayers = function(team = false, radius = false, alive = true)
 	{
 		local resultarray = []
-
+		
 		if (!(!radius))
 		{
 			for (local player; player = Entities.FindByClassnameWithin(player, "player", radius[0], radius[1]); )
 			{
 				if (!(!team)) { if (player.GetTeam() != team) continue }
 				if (alive) { if (!player.IsAlive()) continue }
-
+				
 				resultarray.append(player)
 			}
 		}
-
+		
 		else
 		{
 			local maxclients = MaxClients().tointeger()
-
+			
 			for (local i = 1; i <= maxclients; i++)
 			{
 				local player = PlayerInstanceFromIndex(i)
-
+				
 				if (player == null) continue
-
+				
 				if (!(!team)) { if (player.GetTeam() != team) continue }
 				if (alive) { if (!player.IsAlive()) continue }
-
+				
 				resultarray.append(player)
 			}
 		}
@@ -290,20 +293,20 @@
 	SpawnNavBrush = function(name, pos, xyz1, xyz2, tagname = false)
 	{
 		if (!tagname) tagname = name.slice(4)
-
+		
 		local navbrush = SpawnEntityFromTable("func_nav_avoid", { targetname = name, origin = pos, tags = tagname })
 
 		navbrush.KeyValueFromInt("solid", 2)
 		navbrush.KeyValueFromString("mins", xyz1)
 		navbrush.KeyValueFromString("maxs", xyz2)
-
+		
 		local navbrush2 = SpawnEntityFromTable("func_nav_avoid", { targetname = name, origin = pos, tags = tagname }) // do it twice just to make sure
 
 		navbrush2.KeyValueFromInt("solid", 2)
 		navbrush2.KeyValueFromString("mins", xyz1)
 		navbrush2.KeyValueFromString("maxs", xyz2)
 	}
-
+	
 	SnapVectorToGround = function(pos, offset = false)
 	{
 		local tracetable =
@@ -312,13 +315,13 @@
 			end = pos - Vector(0, 0, 5000)
 			mask = -1
 		}
-
+		
 		TraceLineEx(tracetable)
-
+		
 		if (!offset) return tracetable.pos
 		else		 return (tracetable.pos + Vector(0, 0, offset))
 	}
-
+	
 	CreatePathHologram = function(where, angle)
 	{
 		local projector = SpawnEntityFromTable("prop_dynamic",
@@ -327,7 +330,7 @@
 			model 			   = "models/props_mvm/hologram_projector.mdl"
 			shadowcastdist	   = 0
 		})
-
+		
 		local hologram = SpawnEntityFromTable("prop_dynamic",
 		{
 			origin             = SnapVectorToGround(where, 5.0)
@@ -337,32 +340,32 @@
 			disableshadows     = 1
 		})
 	}
-
+	
 	GiveNavAvoidToNavArea = function(name, area, tag = "", height = 500.0)
 	{
 		local mins = (0 - (area.GetSizeX() / 2.0)).tostring() + " " + (0 - (area.GetSizeY() / 2.0)).tostring() + " " + (0 - (height / 2.0)).tostring()
 		local maxs = (area.GetSizeX() / 2.0).tostring() + " " + (area.GetSizeY() / 2.0).tostring() + " " + (height / 2.0).tostring()
-
+		
 		local avoid = SpawnEntityFromTable("func_nav_avoid",
 		{
 			origin           = area.GetCenter()
 			tags             = tag
 		})
-
+		
 		avoid.KeyValueFromInt("solid", 2)
 		avoid.KeyValueFromString("mins", mins)
 		avoid.KeyValueFromString("maxs", maxs)
 	}
-
+	
 	ConnectNavAreas = function(navarray) { foreach (pair in navarray) NavMesh.GetNavAreaByID(pair[0]).ConnectTo(NavMesh.GetNavAreaByID(pair[1]), NavMesh.GetNavAreaByID(pair[0]).ComputeDirection(NavMesh.GetNavAreaByID(pair[1]).GetCenter())) }
-
+	
 	DisconnectNavAreas = function(navarray) { foreach (pair in navarray) NavMesh.GetNavAreaByID(pair[0]).Disconnect(NavMesh.GetNavAreaByID(pair[1])) }
-
+	
 	UnblockNavAreas = function(navarray) { foreach (nav in navarray) NavMesh.GetNavAreaByID(nav).UnblockArea() }
-
+	
 	EmitGlobalSound = function(sound)
 	{
-		SendGlobalGameEvent("teamplay_broadcast_audio",
+		SendGlobalGameEvent("teamplay_broadcast_audio", 
 		{
 			team             = -1,
 			sound            = sound
@@ -370,16 +373,16 @@
 			player           = -1
 		})
 	}
-
+	
 	StopGlobalSound = function(sound)
 	{
-		SendGlobalGameEvent("teamplay_broadcast_audio",
+		SendGlobalGameEvent("teamplay_broadcast_audio", 
 		{
 			team             = -1,
 			sound            = sound,
 			additional_flags = 4,
 			player           = -1
-		})
+		})	
 	}
 
 	ImprovedCashCollection_Think = function()
@@ -396,7 +399,7 @@
 				}
 			}
 		}
-
+		
 		catch (e) { return }
 
 		return -1
@@ -405,7 +408,7 @@
 	AttachGlow = function(color)
 	{
 		local scope = self.GetScriptScope()
-
+		
 		self.KeyValueFromString("targetname", "glow_target")
 
 		scope.glow <- SpawnEntityFromTable("tf_glow",
@@ -414,12 +417,12 @@
 			target           	  = "glow_target"
 			GlowColor             = color
 		})
-
+		
 		self.KeyValueFromString("targetname", "")
-
+		
 		glow.AcceptInput("SetParent", "!activator", self, null) // parenting a tf_glow fixes issues where it doesn't render if it's too far from you
 	}
-
+	
 	Clamp = function(val, minVal, maxVal)
 	{
 		if (maxVal < minVal)   return maxVal
@@ -427,18 +430,18 @@
 		else if (val > maxVal) return maxVal
 		else 				   return val
 	}
-
+	
 	RemapValClamped = function(val, A, B, C, D)
 	{
 		if (A == B) return ((val >= B) ? D : C)
-
+	
 		local cVal = (val - A) / (B - A)
-
+		
 		cVal = Clamp(cVal, 0.0, 1.0)
 
 		return (C + (D - C) * cVal)
 	}
-
+	
 	SetDestroyCallback = function(entity, callback) // credit goes to ficool2 for function code
 	{
 		entity.ValidateScriptScope()
@@ -462,14 +465,14 @@
 							scope.self <- entity
 							callback.pcall(scope)
 						}
-
+						
 						delete parent[keytodelete]
 					}
 				}
 			)
 		)
 	}
-
+	
 	CameraFix = function() // credit goes to ficool2 for function code
 	{
 		if (!("SetInputHook" in getroottable()))
@@ -483,15 +486,15 @@
 				local scope = entity.GetScriptScope();
 				if (post_func)
 				{
-					local wrapper_func = function()
-					{
-						_PostInputScope = scope;
+					local wrapper_func = function() 
+					{ 
+						_PostInputScope = scope; 
 						_PostInputFunc  = post_func;
 						if (pre_func)
 							return pre_func.call(scope);
 						return true;
 					};
-
+					
 					scope["Input" + input]           <- wrapper_func;
 					scope["Input" + input.tolower()] <- wrapper_func;
 				}
@@ -501,7 +504,7 @@
 					scope["Input" + input.tolower()] <- pre_func;
 				}
 			}
-
+			
 			getroottable().setdelegate(
 			{
 				_delslot = function(k)
@@ -511,10 +514,10 @@
 						_PostInputFunc.call(_PostInputScope);
 						_PostInputFunc = null;
 					}
-
+					
 					rawdelete(k);
 				}
-			});
+			});		
 		}
 
 		if (!("CameraFixer" in getroottable()))
@@ -529,7 +532,7 @@
 					NetProps.SetPropInt(activator, "m_lifeState", 0);
 					NetProps.SetPropEntity(self, "m_hPlayer", activator);
 				}
-
+				
 				return true;
 			}
 
@@ -541,29 +544,29 @@
 					NetProps.SetPropInt(activator, "m_takedamage", 2);
 				}
 			}
-
+			
 			::CameraDisableAll <- function()
 			{
 				for (local player; player = Entities.FindByClassname(player, "player");)
 					EntFireByHandle(CameraFixer, "Disable", "", -1, player, player);
 				EntFireByHandle(CameraFixer, "Kill", "", 1, null, null);
 			}
-
+			
 			::CameraFixer <- Entities.CreateByClassname("point_viewcontrol");
 			::CameraFixer.KeyValueFromString("classname", "camera_fixer");
 			::CameraFixer.AddEFlags(1);
-			SetInputHook(CameraFixer, "Disable", CameraFixPre, CameraFixPost);
+			SetInputHook(CameraFixer, "Disable", CameraFixPre, CameraFixPost);	
 
-			SpawnEntityFromTable("logic_eventlistener",
-			{
+			SpawnEntityFromTable("logic_eventlistener", 
+			{ 
 				classname	 = "move_rope",
 				eventname    = "teamplay_round_start",
 				IsEnabled    = true,
 				OnEventFired = "worldspawn,CallScriptFunction,CameraDisableAll,-1,-1",
 			});
 
-			SpawnEntityFromTable("logic_eventlistener",
-			{
+			SpawnEntityFromTable("logic_eventlistener", 
+			{ 
 				classname	 = "move_rope",
 				eventname    = "recalculate_holidays",
 				IsEnabled    = true,
@@ -576,34 +579,34 @@
 			SetInputHook(self, "Disable", CameraFixPre, CameraFixPost);
 		}
 	}
-
+	
 	IsInside = function(vector, min, max) { return vector.x >= min.x && vector.x <= max.x && vector.y >= min.y && vector.y <= max.y && vector.z >= min.z && vector.z <= max.z }
-
+	
 	FreeUpRobotSlots = function(amount)
 	{
 		// collect all bots first to determine who deserves death
-
+		
 		local slotstoclear
 		local botarray = []
 		local deathpriority = []
-
+		
 		for (local i = 1; i <= MaxClients().tointeger(); i++)
 		{
 			local player = PlayerInstanceFromIndex(i)
-
+			
 			if (player == null) continue
 			if (player.GetTeam() != 3) continue
 			if (!player.IsAlive()) continue
-
+			
 			botarray.append(player)
-
+			
 			ClientPrint(null,3,"" + NetProps.GetPropString(player, "m_szNetname") + " " + player.GetPlayerClass())
 		}
 
 		slotstoclear = (botarray.len() + amount) - 22
-
+		
 		if (slotstoclear < 0) return // no need to free up slots when there is still room
-
+		
 		botarray = botarray.filter(function(index, bot) { return (!bot.IsMiniBoss() && bot != null) })
 
 		ClientPrint(null,3,"origslotstoclear: " + slotstoclear)
@@ -614,20 +617,20 @@
 		for (local i = slotstoclear; i > 0; i--)
 		{
 			ClientPrint(null,3,"slotstoclear: " + i)
-
+			
 			if (i > 0) // destroy a random robot to make room for another
 			{
 				deathpriority[0].Teleport(true, Vector(0, 0, -3000), false, QAngle(), false, Vector())
 				deathpriority[0].TakeDamage(10000.0, 64, null)
 				deathpriority[0].ForceChangeTeam(1, true)
-
+				
 				ClientPrint(null,3,"destroyed: " + NetProps.GetPropString(deathpriority[0], "m_szNetname") + " to make room")
-
+				
 				deathpriority.remove(0)
 			}
 		}
 	}
-
+	
 	DisableRomevision = function()
 	{
 		for (local ent; ent = Entities.FindByModel(ent, "models/bots/boss_bot/carrier.mdl"); )
@@ -637,7 +640,7 @@
 			NetProps.SetPropIntArray(ent, "m_nModelIndexOverrides", PrecacheModel("models/bots/boss_bot/carrier.mdl"), 2)
 			NetProps.SetPropIntArray(ent, "m_nModelIndexOverrides", PrecacheModel("models/bots/boss_bot/carrier.mdl"), 3)
 		}
-
+		
 		for (local ent; ent = Entities.FindByModel(ent, "models/bots/boss_bot/carrier_parts.mdl"); )
 		{
 			NetProps.SetPropIntArray(ent, "m_nModelIndexOverrides", PrecacheModel("models/bots/boss_bot/carrier_parts.mdl"), 0)
@@ -645,10 +648,10 @@
 			NetProps.SetPropIntArray(ent, "m_nModelIndexOverrides", PrecacheModel("models/bots/boss_bot/carrier_parts.mdl"), 2)
 			NetProps.SetPropIntArray(ent, "m_nModelIndexOverrides", PrecacheModel("models/bots/boss_bot/carrier_parts.mdl"), 3)
 		}
-
+		
 		strip_romevision_items = true
 	}
-
+	
 	GlobalBotTagCheck = function()
 	{
 		if (!sigmod)
@@ -660,20 +663,20 @@
 				NetProps.SetPropInt(self, "m_iPlayerSkinOverride", 0)
 			}
 		}
-
+		
 		if (strip_romevision_items)
 		{
 			for (local child = self.FirstMoveChild(); child != null; child = child.NextMovePeer())
 			{
 				if (child.GetClassname() == "tf_wearable" && child.GetModelName().find("tw_") != null) EntFireByHandle(child, "RunScriptCode", "self.DisableDraw()", -1.0, null, null)
 			}
-		}
-
+		} 
+		
 		if (self.HasBotTag("disband_squad")) self.DisbandCurrentSquad()
 		if (self.HasBotTag("shuffle")) BotShuffler()
-
+		
 		if (self.HasBotTag("blimp")) AddThinkToEnt(self, "BlimpSetup_Think")
-
+		
 		if (self.HasBotTag("money"))
 		{
 			self.Teleport(true, moneydrop, false, QAngle(), false, Vector())
@@ -681,11 +684,11 @@
 			self.ForceChangeTeam(1, true)
 		}
 	}
-
+	
 	BombCarrierSpawnSpeedUp_Think = function()
 	{
 		if (thinkertick % 7 != 0) return
-
+		
 		if (NetProps.GetPropBool(objective_resource_entity, "m_bMannVsMachineBetweenWaves") == false)
 		{
 			for (local i = 1; i <= MaxClients().tointeger(); i++)
@@ -697,13 +700,13 @@
 				{
 					if (player.InCond(51) && !player.HasBotAttribute(32768)) player.AddCustomAttribute("CARD: move speed bonus", 10, -1)
 					else player.RemoveCustomAttribute("CARD: move speed bonus")
-
+					
 					if (GetMapName() == "mvm_powerplant_rc1")
 					{
 						if (!bomb_placement_adjusted)
 						{
 							if (current_bombpath == "right") player.Teleport(true, Vector(-1056, 3312, 96), false, QAngle(0, 0, 0), false, Vector(0, 0, 0)) // bots will disobey bomb path if they don't spawn from spawnbot_right
-
+							
 							bomb_placement_adjusted = true
 						}
 					}
@@ -711,45 +714,45 @@
 			}
 		}
 	}
-
+	
 	BotShuffler = function()
 	{
 		if (self.HasBotTag("shuffle"))
 		{
 			self.RemoveBotTag("shuffle")
-
+			
 			local maxchance = 0
-
+			
 			local order_array = []
 			local name_array = []
-
+			
 			local wavespawn
-
+			
 			foreach (tag, entries in shuffle_wavespawn_table)
 			{
 				if (!self.HasBotTag(tag)) continue
-
+				
 				for (local i = 0; i <= entries.amounts.len() - 1; i++)
 				{
 					maxchance = maxchance + entries.amounts[i]
 					order_array.append(entries.amounts[i])
 				}
-
+				
 				for (local i = 0; i <= entries.names.len() - 1; i++) name_array.append(entries.names[i])
-
+				
 				wavespawn = tag
 			}
-
+			
 			for (local i = 1; i <= order_array.len() - 1; i++) order_array[i] = order_array[i - 1] + order_array[i]
 
 			local choice = RandomInt(1, maxchance)
-
+			
 			for (local i = 0; i <= order_array.len() - 1; i++)
 			{
 				if (choice <= order_array[i])
 				{
 					BotTransformer(name_array[i])
-
+					
 					foreach (tag, entries in shuffle_wavespawn_table)
 					{
 						if (tag != wavespawn) continue
@@ -761,7 +764,7 @@
 			}
 		}
 	}
-
+	
 	TankFinder_Think = function()
 	{
 		for (local tank; tank = Entities.FindByName(tank, "tankboss"); )
@@ -772,25 +775,25 @@
 				if (tank.GetModelName() == "models/bots/boss_bot/boss_tank_damage1.mdl") NetProps.SetPropIntArray(tank, "m_nModelIndexOverrides", PrecacheModel("models/bots/boss_bot/boss_tank_damage1.mdl"), 3)
 				if (tank.GetModelName() == "models/bots/boss_bot/boss_tank_damage2.mdl") NetProps.SetPropIntArray(tank, "m_nModelIndexOverrides", PrecacheModel("models/bots/boss_bot/boss_tank_damage2.mdl"), 3)
 				if (tank.GetModelName() == "models/bots/boss_bot/boss_tank_damage3.mdl") NetProps.SetPropIntArray(tank, "m_nModelIndexOverrides", PrecacheModel("models/bots/boss_bot/boss_tank_damage3.mdl"), 3)
-
+			
 				local child_array = []
-
+				
 				for (local child = tank.FirstMoveChild(); child != null; child = child.NextMovePeer()) child_array.append(child)
-
+				
 				foreach (child in child_array) NetProps.SetPropIntArray(child, "m_nModelIndexOverrides", NetProps.GetPropIntArray(child, "m_nModelIndexOverrides", 0), 3)
 			}
-
+			
 			if (EntityOutputs.HasAction(tank, "OnKilled")) continue
 			else EntityOutputs.AddOutput(tank, "OnKilled", "gamerules", "CallScriptFunction", "CleanUpTank", -1.0, -1.0)
 		}
-
+		
 		// for (local blimp; blimp = Entities.FindByName(blimp, "blimpboss"); )
 		// {
 			// if (blimp.GetScriptScope() != null) continue
 			// else SetUpBlimp(blimp)
 		// }
 	}
-
+	
 	CleanUpTank = function()
 	{
 		tanks_in_wave = tanks_in_wave - 1
@@ -804,10 +807,10 @@
 			if (NetProps.GetPropStringArray(objective_resource_entity, "m_iszMannVsMachineWaveClassNames.", i) == name) return true
 			if (NetProps.GetPropStringArray(objective_resource_entity, "m_iszMannVsMachineWaveClassNames2.", i) == name) return true
 		}
-
+		
 		return false
 	}
-
+	
 	GetIconType = function(name)
 	{
 		for (local i = 0; i <= 11; i++)
@@ -816,7 +819,7 @@
 			if (NetProps.GetPropStringArray(objective_resource_entity, "m_iszMannVsMachineWaveClassNames2.", i) == name) return NetProps.GetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassFlags2.", i)
 		}
 	}
-
+	
 	GetIconCount = function(name)
 	{
 		for (local i = 0; i <= 11; i++)
@@ -825,10 +828,10 @@
 			if (NetProps.GetPropStringArray(objective_resource_entity, "m_iszMannVsMachineWaveClassNames2.", i) == name) return NetProps.GetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassCounts2.", i)
 		}
 	}
-
+	
 	GetTotalEnemyCount = function() { return NetProps.GetPropInt(objective_resource_entity, "m_nMannVsMachineWaveEnemyCount") }
 	SetTotalEnemyCount = function(amount) { NetProps.SetPropInt(objective_resource_entity, "m_nMannVsMachineWaveEnemyCount", amount) }
-
+	
 	HideIcon = function(name) // IMPORTANT: adding the dot to netprop names here will fix issues where the third element in the array is inaccessible!
 	{
 		for (local i = 0; i <= 11; i++)
@@ -836,19 +839,19 @@
 			if (NetProps.GetPropStringArray(objective_resource_entity, "m_iszMannVsMachineWaveClassNames.", i) == name)
 			{
 				if (GetIconType(name) == 1) SetTotalEnemyCount(GetTotalEnemyCount() - GetIconCount(name))
-
+				
 				NetProps.SetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassFlags.", 0, i)
 			}
-
+		
 			if (NetProps.GetPropStringArray(objective_resource_entity, "m_iszMannVsMachineWaveClassNames2.", i) == name)
 			{
 				if (GetIconType(name) == 1) SetTotalEnemyCount(GetTotalEnemyCount() - GetIconCount(name))
-
+				
 				NetProps.SetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassFlags2.", 0, i)
 			}
 		}
 	}
-
+	
 	UnhideIcon = function(name, flag)
 	{
 		for (local i = 0; i <= 11; i++)
@@ -857,26 +860,48 @@
 			if (NetProps.GetPropStringArray(objective_resource_entity, "m_iszMannVsMachineWaveClassNames2.", i) == name) NetProps.SetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassFlags2.", flag, i)
 		}
 	}
-
+	
+	AddIcon = function(name, flag, amount)
+	{
+		for (local i = 11; i >= 0; i--)
+		{
+			if (NetProps.GetPropStringArray(objective_resource_entity, "m_iszMannVsMachineWaveClassNames2.", i) == "")
+			{
+				NetProps.SetPropStringArray(objective_resource_entity, "m_iszMannVsMachineWaveClassNames2.", name, i)
+				NetProps.SetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassFlags2.", flag, i)
+				NetProps.SetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassCounts2.", amount, i)
+				break
+			}
+			
+			if (NetProps.GetPropStringArray(objective_resource_entity, "m_iszMannVsMachineWaveClassNames.", i) == "")
+			{
+				NetProps.SetPropStringArray(objective_resource_entity, "m_iszMannVsMachineWaveClassNames.", name, i)
+				NetProps.SetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassFlags.", flag, i)
+				NetProps.SetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassCounts.", amount, i)
+				break
+			}
+		}
+	}
+	
 	AddToIcon = function (name, amount)
 	{
 		for (local i = 0; i <= 11; i++)
 		{
 			local count = NetProps.GetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassCounts.", i)
-
+			
 			if (NetProps.GetPropStringArray(objective_resource_entity, "m_iszMannVsMachineWaveClassNames.", i) == name)
 			{
 				if (GetIconType(name) == 1) SetTotalEnemyCount(GetTotalEnemyCount() + amount)
 				NetProps.SetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassCounts.", count + amount, i)
 			}
-
+			
 			if (NetProps.GetPropStringArray(objective_resource_entity, "m_iszMannVsMachineWaveClassNames2.", i) == name)
 			{
 				if (GetIconType(name) == 1) SetTotalEnemyCount(GetTotalEnemyCount() + amount)
 				NetProps.SetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassCounts2.", count + amount, i)
 			}
 		}
-
+		
 		// local totalcount = NetProps.GetPropInt(objective_resource_entity, "m_nMannVsMachineWaveEnemyCount")
 		// NetProps.SetPropInt(objective_resource_entity, "m_nMannVsMachineWaveEnemyCount", totalcount + amount)
 	}
@@ -884,12 +909,12 @@
 	HideErrors = function()
 	{
 		ClientPrint(null,3,"\x07FF3F3FThe errors about missing spawn entities are harmless, please ignore them.\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n")
-
+		
 		if ("MissionInitMessage" in PEA) MissionInitMessage()
-
+		
 		firstload = false
 	}
-
+	
 	ConvertTankIconsToBlimp = function(convertall, amount = 1)
 	{
 		if (convertall)
@@ -901,7 +926,7 @@
 					NetProps.SetPropStringArray(objective_resource_entity, "m_iszMannVsMachineWaveClassNames", "blimp2_lite", i)
 					blimps_in_wave = NetProps.GetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassCounts", i)
 				}
-
+				
 				if (NetProps.GetPropStringArray(objective_resource_entity, "m_iszMannVsMachineWaveClassNames2", i) == "tank")
 				{
 					NetProps.SetPropStringArray(objective_resource_entity, "m_iszMannVsMachineWaveClassNames2", "blimp2_lite", i)
@@ -909,7 +934,7 @@
 				}
 			}
 		}
-
+		
 		else
 		{
 			for (local i = 0; i <= 11; i++)
@@ -920,14 +945,14 @@
 					NetProps.SetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassCounts", amount, i)
 					blimps_in_wave = NetProps.GetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassCounts", i)
 				}
-
+				
 				if (NetProps.GetPropStringArray(objective_resource_entity, "m_iszMannVsMachineWaveClassNames2", i) == "blimp2_lite")
 				{
 					NetProps.SetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassFlags2", 9, i)
 					NetProps.SetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassCounts2", amount, i)
 					blimps_in_wave = NetProps.GetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassCounts2", i)
 				}
-
+				
 				if (NetProps.GetPropStringArray(objective_resource_entity, "m_iszMannVsMachineWaveClassNames", i) == "tank")
 				{
 					NetProps.SetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassCounts", NetProps.GetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassCounts", i) - amount, i)
@@ -941,7 +966,7 @@
 			}
 		}
 	}
-
+	
 	InstantReady_Think = function()
 	{
 		if (NetProps.GetPropBoolArray(gamerules_entity, "m_bPlayerReady", 1) && !countdown_skipped)
@@ -952,7 +977,7 @@
 	}
 
 	ThinksTable = {}
-
+	
 	GlobalThinker = function()
 	{
 		thinkertick = thinkertick + 1
@@ -961,19 +986,19 @@
 
 		return -1
 	}
-
+	
 	AssignThinkToThinksTable = function(think) { if (!(think in getroottable()["ThinksTable"])) getroottable()["ThinksTable"][think] <- getroottable()[think] }
 
 	RemoveThinkFromThinksTable = function(think) { delete getroottable()["ThinksTable"][think] }
-
+	
 	BlimpSetup_Think = function()
 	{
 		local scope = self.GetScriptScope()
-
+		
 		if (!("train" in scope))
 		{
 			self.SetMoveType(0, 0)
-
+			
 			scope.train <- SpawnEntityFromTable("func_tracktrain",
 			{
 				targetname              = "blimp_train"
@@ -989,7 +1014,7 @@
 				renderamt				= 0
 				solid					= 0
 			})
-
+			
 			scope.blimp <- SpawnEntityFromTable("base_boss",
 			{
 				targetname	  = "blimpboss"
@@ -1003,24 +1028,24 @@
 
 			blimp.ResetSequence(2)
 			if (sigmod) blimp.SetPlaybackRate(0.015)
-
+			
 			NetProps.SetPropInt(blimp, "m_bloodColor", -1.0)
-
+			
 			train.ValidateScriptScope()
 			train.GetScriptScope().parented_blimp <- blimp
-
+			
 			blimp.ValidateScriptScope()
 			blimp.GetScriptScope().pathtrain <- train
-
+			
 			AttachGlow.call(blimp.GetScriptScope(), "125 168 196 255")
-
+			
 			EmitGlobalSound("MVM.TankStart")
 			EmitGlobalSound("Announcer.MVM_Tank_Alert_Spawn")
-
+			
 			blimp.SetModelScale(("blimp_scale" in PEA) ? blimp_scale : 1, -1)
-
+			
 			AddThinkToEnt(blimp, "Blimp_Think")
-
+			
 			scope.blimpcallbacks <-
 			{
 				OnGameEvent_player_death = function(params)
@@ -1030,28 +1055,28 @@
 					if (dead_player == self)
 					{
 						moneydrop = blimp.GetOrigin()
-
+						
 						DispatchParticleEffect("explosionTrail_seeds_mvm", blimp.GetOrigin(), Vector(0, 90, 0))
 						DispatchParticleEffect("fluidSmokeExpl_ring_mvm", blimp.GetOrigin(), Vector(0, 90, 0))
-
+						
 						ScreenShake(blimp.GetOrigin(), 25.0, 5.0, 5.0, 1000.0, 0, true)
 
 						EmitGlobalSound("MVM.TankExplodes")
 						EmitGlobalSound("MVM.TankEnd")
 						EmitGlobalSound("Announcer.MVM_General_Destruction")
-
+						
 						AddToIcon("blimp2_lite", -1)
 
 						delete blimpcallbacks
 					}
 				}
 			}
-
+			
 			foreach (name, callback in blimpcallbacks) blimpcallbacks[name] = callback.bindenv(scope)
-
+			
 			__CollectGameEventCallbacks(blimpcallbacks)
 		}
-
+		
 		self.SetHealth(self.GetMaxHealth() - (blimp.GetMaxHealth() - blimp.GetHealth()))
 
 		if (self.GetHealth() <= 0)
@@ -1060,7 +1085,7 @@
 			self.TakeDamage(10000.0, 64, null)
 		}
 	}
-
+	
 	CleanUpBlimp = function()
 	{
 		if (NetProps.GetPropBool(objective_resource_entity, "m_bMannVsMachineBetweenWaves") == true) return // don't do cleanup if the blimp was the last enemy in the wave
@@ -1071,11 +1096,11 @@
 		{
 			if (NetProps.GetPropStringArray(objective_resource_entity, "m_iszMannVsMachineWaveClassNames", i) == "blimp2_lite") NetProps.SetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassCounts", blimps_in_wave, i)
 			if (NetProps.GetPropStringArray(objective_resource_entity, "m_iszMannVsMachineWaveClassNames2", i) == "blimp2_lite") NetProps.SetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassCounts2", blimps_in_wave, i)
-
+			
 			if (NetProps.GetPropStringArray(objective_resource_entity, "m_iszMannVsMachineWaveClassNames", i) == "tank") NetProps.SetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassCounts", tanks_in_wave, i)
 			if (NetProps.GetPropStringArray(objective_resource_entity, "m_iszMannVsMachineWaveClassNames2", i) == "tank") NetProps.SetPropIntArray(objective_resource_entity, "m_nMannVsMachineWaveClassCounts2", tanks_in_wave, i)
 		}
-
+		
 		for (local train; train = Entities.FindByName(train, "blimp_train"); ) if (!train.GetScriptScope().parented_blimp.IsValid()) train.Kill()
 		for (local cash; cash = Entities.FindByClassname(cash, "item_currencypack_custom"); ) AddThinkToEnt(cash, "ImprovedCashCollection_Think")
 	}
@@ -1083,16 +1108,16 @@
 	Blimp_Think = function()
 	{
 		local scope = self.GetScriptScope()
-
+		
 		if (!("DeployBomb" in scope))
 		{
 			PrecacheSound("npc/combine_gunship/ping_search.wav")
-
+			
 			scope.nextpingtime <- Time() + 5.0
 			scope.deployed <- false
-
+			
 			scope.DeployBomb <- function()
-			{
+			{	
 				self.ResetSequence(1)
 				if (sigmod) self.SetPlaybackRate(0.013)
 
@@ -1108,26 +1133,26 @@
 				})
 			}
 		}
-
+		
 		self.SetOrigin(scope.pathtrain.GetOrigin())
 		self.SetAbsAngles(QAngle(0, scope.pathtrain.GetAbsAngles().y, 0))
 		self.GetLocomotionInterface().Reset()
-
+		
 		if (self.GetModelName() == "models/bots/boss_bot/boss_tank.mdl" 		|| self.GetModelName() == "models/bots/tw2/boss_bot/boss_tank.mdl") 		NetProps.SetPropIntArray(self, "m_nModelIndexOverrides", PrecacheModel("models/bots/boss_bot/boss_blimp.mdl"), 0)
 		if (self.GetModelName() == "models/bots/boss_bot/boss_tank_damage1.mdl" || self.GetModelName() == "models/bots/tw2/boss_bot/boss_tank_damage1.mdl") NetProps.SetPropIntArray(self, "m_nModelIndexOverrides", PrecacheModel("models/bots/boss_bot/boss_blimp_damage1.mdl"), 0)
 		if (self.GetModelName() == "models/bots/boss_bot/boss_tank_damage2.mdl" || self.GetModelName() == "models/bots/tw2/boss_bot/boss_tank_damage2.mdl") NetProps.SetPropIntArray(self, "m_nModelIndexOverrides", PrecacheModel("models/bots/boss_bot/boss_blimp_damage2.mdl"), 0)
 		if (self.GetModelName() == "models/bots/boss_bot/boss_tank_damage3.mdl" || self.GetModelName() == "models/bots/tw2/boss_bot/boss_tank_damage3.mdl") NetProps.SetPropIntArray(self, "m_nModelIndexOverrides", PrecacheModel("models/bots/boss_bot/boss_blimp_damage3.mdl"), 0)
-
+		
 		if (self.GetModelName() == "models/bots/boss_bot/boss_tank.mdl" 		|| self.GetModelName() == "models/bots/tw2/boss_bot/boss_tank.mdl") 		NetProps.SetPropIntArray(self, "m_nModelIndexOverrides", PrecacheModel("models/bots/boss_bot/boss_blimp.mdl"), 3)
 		if (self.GetModelName() == "models/bots/boss_bot/boss_tank_damage1.mdl" || self.GetModelName() == "models/bots/tw2/boss_bot/boss_tank_damage1.mdl") NetProps.SetPropIntArray(self, "m_nModelIndexOverrides", PrecacheModel("models/bots/boss_bot/boss_blimp_damage1.mdl"), 3)
 		if (self.GetModelName() == "models/bots/boss_bot/boss_tank_damage2.mdl" || self.GetModelName() == "models/bots/tw2/boss_bot/boss_tank_damage2.mdl") NetProps.SetPropIntArray(self, "m_nModelIndexOverrides", PrecacheModel("models/bots/boss_bot/boss_blimp_damage2.mdl"), 3)
 		if (self.GetModelName() == "models/bots/boss_bot/boss_tank_damage3.mdl" || self.GetModelName() == "models/bots/tw2/boss_bot/boss_tank_damage3.mdl") NetProps.SetPropIntArray(self, "m_nModelIndexOverrides", PrecacheModel("models/bots/boss_bot/boss_blimp_damage3.mdl"), 3)
-
+		
 		self.StudioFrameAdvance()
 		self.DispatchAnimEvents(self)
-
+		
 		if (deployed) return -1
-
+		
 		if (Time() > nextpingtime)
 		{
 			EmitSoundEx(
@@ -1140,17 +1165,17 @@
 				flags = 0,
 				channel = 6
 			})
-
+			
 			nextpingtime = Time() + 5.0
 		}
-
+		
 		if (self.GetCycle() == 1.0)
 		{
 			if (self.GetSequence() == 2) self.SetCycle(0)
 			else
 			{
 				deployed = true
-
+				
 				switch (GetMapName())
 				{
 					case "mvm_hanami_rc1":
@@ -1159,7 +1184,7 @@
 						EntFire("hatch_destroy_relay", "Trigger")
 						break
 					}
-
+					
 					case "mvm_null_b9c":
 					{
 						soldier_statue.Kill()
@@ -1173,7 +1198,7 @@
 						EntFire("trigger_hurt_hatch_fire", "Enable")
 						break
 					}
-
+					
 					case "mvm_quetzal_rc5": EntFire("boss_deploy_relay", "Trigger"); break
 				}
 			}
@@ -1181,7 +1206,7 @@
 
 		return -1
 	}
-
+	
 	DEBUG_CALLBACKS =
 	{
 		OnGameEvent_player_say = function(params)
@@ -1191,10 +1216,10 @@
 			if (params.text == "1")
 			{
 				foreach (player in GetAllPlayers(3)) player.TakeDamageCustom(player, player, null, Vector(), Vector(), 9999999.9, 1024, 0)
-
+				
 				// PrecacheModel("models/player/pyro.mdl")
 				// player.SetCustomModelWithClassAnimations("models/player/pyro.mdl")
-
+				
 			    // local wearable = SpawnEntityFromTable("tf_wearable",
 				// {
 					// origin = player.GetOrigin()
@@ -1202,7 +1227,7 @@
 					// skin = 0
 					// effects = 129
 				// })
-
+				
 				// EntFireByHandle(wearable, "SetParent", "!activator", -1, player, null)
 				// NetProps.SetPropInt(wearable, "m_fEffects", 129)
 			}
@@ -1229,15 +1254,16 @@ CTFBot.Zombify <- function()
 	NetProps.SetPropBool(this, "m_bForcedSkin", true)
 	NetProps.SetPropInt(this, "m_nForcedSkin", 5)
 	NetProps.SetPropInt(this, "m_iPlayerSkinOverride", 1)
-	this.GetWearable(format("models/player/items/%s/%s_zombie.mdl", class_integers[this.GetPlayerClass()], class_integers[this.GetPlayerClass()]))
+	this.GetWearableItem(zombieitems[this.GetPlayerClass() - 1])
+	// this.GetWearable(format("models/player/items/%s/%s_zombie.mdl", class_integers[this.GetPlayerClass()], class_integers[this.GetPlayerClass()]))
 	this.SetCustomModelWithClassAnimations(format("models/player/%s.mdl", class_integers[this.GetPlayerClass()]))
-
+	
 	if (sigmod)
 	{
 		this.AddCustomAttribute("use human voice", 1, -1.0)
 		this.AddCustomAttribute("voice pitch scale", 0.65, -1.0)
 	}
-
+	
 	else this.AddCustomAttribute("voice pitch scale", 0, -1.0)
 }
 
@@ -1248,27 +1274,27 @@ CTFPlayer.GetWeapon <- function(className, itemID)
 	NetProps.SetPropInt(weapon, "m_AttributeManager.m_Item.m_iItemDefinitionIndex", itemID)
 	NetProps.SetPropBool(weapon, "m_AttributeManager.m_Item.m_bInitialized", true)
 	NetProps.SetPropBool(weapon, "m_bValidatedAttachedEntity", true)
-
+	
 	weapon.SetTeam(this.GetTeam())
-
+	
 	NetProps.SetPropInt(weapon, "m_iViewModelIndex", ::PrecacheModel("models/props_mvm/mann_hatch.mdl"))
-
+	
 	Entities.DispatchSpawn(weapon)
 
 	for (local i = 0; i < 8; i++)
 	{
 		local heldWeapon = NetProps.GetPropEntityArray(this, "m_hMyWeapons", i)
-
+		
 		if (heldWeapon == null) continue
 		if (heldWeapon.GetSlot() != weapon.GetSlot()) continue
-
+		
 		heldWeapon.Destroy()
-
+		
 		NetProps.SetPropEntityArray(this, "m_hMyWeapons", null, i)
 		break
 	}
-
-	this.Weapon_Equip(weapon)
+	
+	this.Weapon_Equip(weapon)   
 	this.Weapon_Switch(weapon)
 
 	return weapon
@@ -1283,51 +1309,69 @@ CTFPlayer.GetWearable <- function(model, bonemerge = true, attachment = null, of
 	if (modelIndex == -1) modelIndex = ::PrecacheModel(model)
 
 	local wearable = Entities.CreateByClassname("tf_wearable")
-
+	
 	NetProps.SetPropInt(wearable, "m_nModelIndex", modelIndex)
-
+	
 	wearable.SetSkin(this.GetTeam())
 	wearable.SetTeam(this.GetTeam())
 	wearable.SetSolidFlags(4)
 	wearable.SetCollisionGroup(11)
-
+	
 	NetProps.SetPropBool(wearable, "m_bValidatedAttachedEntity", true)
 	NetProps.SetPropBool(wearable, "m_AttributeManager.m_Item.m_bInitialized", true)
-	NetProps.SetPropInt(wearable, "m_AttributeManager.m_Item.m_iEntityQuality", 0)
-	NetProps.SetPropInt(wearable, "m_AttributeManager.m_Item.m_iEntityLevel", 1)
-	NetProps.SetPropInt(wearable, "m_AttributeManager.m_Item.m_iItemIDLow", 2048)
-	NetProps.SetPropInt(wearable, "m_AttributeManager.m_Item.m_iItemIDHigh", 0)
 
 	wearable.SetOwner(this)
 	Entities.DispatchSpawn(wearable)
-
+	
 	NetProps.SetPropInt(wearable, "m_fEffects", bonemerge ? 1 | 128 : 0)
-
-	NetProps.SetPropEntity(wearable, "m_hMovePeer", this.FirstMoveChild())
-	NetProps.SetPropEntity(this, "m_hMoveChild", wearable)
-	NetProps.SetPropEntity(wearable, "m_hMoveParent", this)
-
-	local origPos = wearable.GetLocalOrigin()
-	wearable.SetLocalOrigin(origPos + Vector(0, 0, 1))
-	wearable.SetLocalOrigin(origPos)
-
-	local origAngles = wearable.GetLocalAngles()
-	wearable.SetLocalAngles(origAngles + QAngle(0, 0, 1))
-	wearable.SetLocalAngles(origAngles)
-
-	local origVel = wearable.GetVelocity()
-	wearable.SetVelocity(origVel + Vector(0, 0, 1))
-	wearable.SetVelocity(origVel)
-
+	
 	wearable.AcceptInput("SetParent", "!activator", this, this)
-
-	if (attachment != null) EntFireByHandle(wearable, "SetParentAttachment", attachment, 0.1, null, null)
-
+	
+	if (attachment != null) // troubleshooting attachments not working
+	{
+		wearable.AcceptInput("SetParentAttachment", attachment, null, null)
+		// EntFireByHandle(wearable, "SetParentAttachment", attachment, 0.1, null, null)
+		// EntFireByHandle(wearable, "SetParentAttachment", attachment, 0.5, null, null)
+		// EntFireByHandle(wearable, "SetParentAttachment", attachment, 1.0, null, null)
+	}
+	
 	if (offsets != null)
 	{
 		EntFireByHandle(wearable, "RunScriptCode", "self.SetLocalOrigin(Vector(" + offsets[0].x + ", " + offsets[0].y + ", " + offsets[0].z + "))", 0.1, null, null)
 		EntFireByHandle(wearable, "RunScriptCode", "self.SetLocalAngles(QAngle(" + offsets[1].x + ", " + offsets[1].y + ", " + offsets[1].z + "))", 0.1, null, null)
 	}
+	
+	else
+	{
+		EntFireByHandle(wearable, "RunScriptCode", "self.SetLocalOrigin(Vector(0, 0, 0))", 0.1, null, null)
+		EntFireByHandle(wearable, "RunScriptCode", "self.SetLocalAngles(QAngle(0, 0, 0))", 0.1, null, null)
+	}
+	
+	wearable.ValidateScriptScope()
+	wearable.GetScriptScope().custom_wearable <- true
+	
+	return wearable
+}
+
+CTFPlayer.GetWearableItem <- function(id)
+{
+	local dummy_Weapon = Entities.CreateByClassname("tf_weapon_parachute")
+	NetProps.SetPropInt(dummy_Weapon, "m_AttributeManager.m_Item.m_iItemDefinitionIndex", 1101)
+	NetProps.SetPropBool(dummy_Weapon, "m_AttributeManager.m_Item.m_bInitialized", true)
+	
+	dummy_Weapon.SetTeam(this.GetTeam())
+	dummy_Weapon.DispatchSpawn()
+	
+	this.Weapon_Equip(dummy_Weapon)
+    
+	local wearable = NetProps.GetPropEntity(dummy_Weapon, "m_hExtraWearable")
+
+	dummy_Weapon.Kill()
+	
+	NetProps.SetPropInt(wearable, "m_AttributeManager.m_Item.m_iItemDefinitionIndex", id)
+
+	NetProps.SetPropBool(wearable, "m_AttributeManager.m_Item.m_bInitialized", true)
+	wearable.DispatchSpawn()
 
 	wearable.ValidateScriptScope()
 	wearable.GetScriptScope().custom_wearable <- true
@@ -1336,6 +1380,9 @@ CTFPlayer.GetWearable <- function(model, bonemerge = true, attachment = null, of
 }
 
 CTFBot.GetWearable <- CTFPlayer.GetWearable
+CTFBot.GetWearableItem <- CTFPlayer.GetWearableItem
+
+CBaseCombatWeapon.GetOwner <- function() { return NetProps.GetPropEntity(this, "m_hOwner") }
 
 if (!("PEA" in getroottable()))	::PEA <- {}
 if (!("PLAYERLOG" in getroottable())) ::PLAYERLOG <- {}
@@ -1357,20 +1404,20 @@ if (!("PEA_GLOBAL_ONETIME" in getroottable())) // declare these variables only o
 		wavewon = false
 		firstload = ("custom_spawns" in PEA) ? true : false
 	}
-
+	
 	foreach (thing, var in PEA_GLOBAL_ONETIME) getroottable()[thing] <- getroottable()["PEA_GLOBAL_ONETIME"][thing]
-
+	
 	for (local i = 1; i <= Constants.Server.MAX_PLAYERS; i++) // run this for when the first player connects to the server and the callback hasn't loaded yet
 	{
 		local player = PlayerInstanceFromIndex(i)
-
+		
 		if (player == null) continue
-
+		
 		player.ValidateScriptScope()
-
+		
 		if (!player.IsFakeClient()) player.ForceRespawn()
 	}
-
+	
 	if ("custom_spawns" in PEA)
 	{
 		foreach (spawn in custom_spawns)
@@ -1384,21 +1431,21 @@ if (!("PEA_GLOBAL_ONETIME" in getroottable())) // declare these variables only o
 				StartDisabled = spawn[2]
 			})
 		}
-
+		
 		for (local ent; ent = Entities.FindByClassname(ent, "info_player_teamspawn"); ) { if (NetProps.GetPropInt(ent, "m_iHammerID") == 0) ent.KeyValueFromString("classname", "entity_sign") }
-
+		
 		NetProps.SetPropFloat(gamerules_entity, "m_flRestartRoundTime", Time())
-
+		
 		foreach (name, callback in PEA.GLOBAL_CALLBACKS) PEA.GLOBAL_CALLBACKS[name] = callback.bindenv(gamerules_entity.GetScriptScope())
 
 		__CollectGameEventCallbacks(PEA.GLOBAL_CALLBACKS)
-
+		
 		return
 	}
 }
 
 else if (firstload) EntFireByHandle(gamerules_entity, "CallScriptFunction", "HideErrors", 0.1, null, null)
-
+	
 HideIcon("noicon")
 
 foreach (think in getroottable()["ThinksTable"]) delete getroottable()["ThinksTable"][think]
@@ -1414,17 +1461,17 @@ switch (GetMapName())
 	case "mvm_meltdown_rc5": break
 	case "mvm_spacepost_rc1": break
 	case "mvm_derelict_rc2": DisableRomevision(); break
-
+	
 	case "mvm_hanami_rc1": break
 	case "mvm_hideout_b3": DisableRomevision(); break
 	case "mvm_hoovydam_b10": DisableRomevision(); EntFire("initMain_roadside", "Trigger"); break
-
+	
 	case "mvm_null_b9a": DisableRomevision(); break
 	case "mvm_decay_rc1": DisableRomevision(); break
-
+	
 	case "mvm_quetzal_rc5": DisableRomevision(); break
 	case "mvm_powerplant_rc1": DisableRomevision(); AssignThinkToThinksTable("BombCarrierSpawnSpeedUp_Think"); break
-
+	
 	case "mvm_underworld_rc2": DisableRomevision(); break
 }
 
@@ -1433,7 +1480,7 @@ AssignThinkToThinksTable("TankFinder_Think")
 if ("CALLBACKS" in PEA)
 {
 	foreach (name, callback in PEA.CALLBACKS) PEA.CALLBACKS[name] = callback.bindenv(gamerules_entity.GetScriptScope()) // this will let us use local functions inside callbacks
-
+	
 	__CollectGameEventCallbacks(PEA.CALLBACKS)
 }
 
@@ -1442,13 +1489,13 @@ foreach (name, callback in PEA.GLOBAL_CALLBACKS) PEA.GLOBAL_CALLBACKS[name] = ca
 __CollectGameEventCallbacks(PEA.GLOBAL_CALLBACKS)
 
 for (local ent; ent = Entities.FindByClassname(ent, "script_wearable"); ) ent.Kill()
-
+	
 if (WaveHasIcon("blimp2_lite")) UnhideIcon("blimp2_lite", 8)
-
+	
 foreach (player in GetAllPlayers(false, false, false))
 {
 	player.ValidateScriptScope()
-
+	
 	if (player.IsFakeClient())
 	{
 		if (!sigmod)
@@ -1457,28 +1504,28 @@ foreach (player in GetAllPlayers(false, false, false))
 			NetProps.SetPropInt(player, "m_nForcedSkin", 0)
 			NetProps.SetPropInt(player, "m_iPlayerSkinOverride", 0)
 		}
-
+		
 		local scope = player.GetScriptScope()
 
 		NetProps.SetPropString(player, "m_iszScriptThinkFunction", "")
-
+		
 		for (local child = player.FirstMoveChild(); child != null; child = child.NextMovePeer())
-		{
+		{ 
 			if ("custom_wearable" in child.GetScriptScope()) { EntFireByHandle(child, "Kill", null, -1.0, null, null); continue }
-
+			
 			child.DisableDraw()
-
+			
 			continue
 		}
-
+		
 		foreach (thing in player.GetScriptScope())
 		{
 			try { thing.GetClassname() }
 			catch (e) { continue }
-
+			
 			if (!thing.IsPlayer()) thing.Kill()
 		}
-
+	
 		player.TerminateScriptScope()
 	}
 }
@@ -1495,9 +1542,9 @@ if (debug)
 			player.AddCurrency(10000)
 		}
 	}
-
+	
 	AssignThinkToThinksTable("InstantReady_Think")
-
+	
 	__CollectGameEventCallbacks(PEA.DEBUG_CALLBACKS)
 }
 
@@ -1511,17 +1558,17 @@ seterrorhandler(function(e)
 		{
 			local Chat = @(m) (printl(m), ClientPrint(player, 2, m))
 			ClientPrint(player, 3, format("\x07FF0000AN ERROR HAS OCCURRED [%s].\nCheck console for details", e))
-
+			
 			Chat(format("\n====== TIMESTAMP: %g ======\nAN ERROR HAS OCCURRED [%s]", Time(), e))
 			Chat("CALLSTACK")
 			local s, l = 2
 			while (s = getstackinfos(l++)) Chat(format("*FUNCTION [%s()] %s line [%d]", s.func, s.src, s.line))
 
 			Chat("LOCALS")
-
+			
 			if (s = getstackinfos(2))
 			{
-				foreach (n, v in s.locals)
+				foreach (n, v in s.locals) 
 				{
 					local t = type(v)
 					t ==    "null" ? Chat(format("[%s] NULL"  , n))    :
@@ -1531,7 +1578,7 @@ seterrorhandler(function(e)
 									 Chat(format("[%s] %s %s" , n, t, v.tostring()))
 				}
 			}
-
+			
 			return
 		}
 	}

--- a/scripts/vscripts/underworld_pea.nut
+++ b/scripts/vscripts/underworld_pea.nut
@@ -1,13 +1,13 @@
 ::PEA <-
-{
+{	
 	wavecount = 6
 	logname = "undead_dread/player.log"
 
 	debug = false
-
+	
 	intel_entity = Entities.FindByName(null, "intel")
-
-	custom_spawns =
+	
+	custom_spawns = 
 	[
 		[ Vector(-576, -2464, -96), "spawnbot_support", 0 ],
 		[ Vector(-576, -2464, -96), "spawnbot_support_2", 0 ],
@@ -15,22 +15,22 @@
 		[ Vector(2296, -2832, 228), "spawnbot_side_support_2", 0 ],
 		[ Vector(1000, -2800, -150), "spawnbot_tunnel", 0 ],
 		[ Vector(1000, -2800, -150), "spawnbot_tunnel_support", 0 ],
-
+		
 		[ Vector(1330, -600, 250), "spawnbot_coffin_front", 0 ],
 		[ Vector(1950, -1100, 300), "spawnbot_coffin_front", 0 ],
 		[ Vector(100, -550, 300), "spawnbot_coffin_front", 0 ],
-
+		
 		[ Vector(-850, 450, -100), "spawnbot_coffin_middle", 0 ],
 		[ Vector(1100, 600, 50), "spawnbot_coffin_middle", 0 ],
 		[ Vector(1700, 1700, 250), "spawnbot_coffin_middle", 0 ],
 		[ Vector(-1200, 1800, 300), "spawnbot_coffin_middle", 0 ],
 		[ Vector(600, 1050, 300), "spawnbot_coffin_middle", 0 ],
-
+		
 		[ Vector(-50, 2400, -350), "spawnbot_coffin_back", 0 ],
 		[ Vector(900, 2500, -100), "spawnbot_coffin_back", 0 ],
 		[ Vector(1150, 3950, 100), "spawnbot_coffin_back", 0 ],
 		[ Vector(-300, 3500, 100), "spawnbot_coffin_back", 0 ],
-
+		
 		[ Vector(-576, -2464, -96), "spawnbot_samurai", 1 ],
 		[ Vector(-576, -2464, -96), "spawnbot_samurai_2", 1 ],
 		[ Vector(-50, 2400, -350), "spawnbot_secretwave", 1 ]
@@ -39,7 +39,7 @@
 	finalpath = []
 
 	medicshotgun_soundarray = ["autodejectedtie02", "jeers05", "specialcompleted02", "specialcompleted12"]
-
+	
 	bombhop_responses =
 	{
 		scout = [2512, 2513, 2514, 2515, 2516, 2517],
@@ -48,9 +48,9 @@
 		sniper = [2335, 2444, 2445],
 		sniper_scope = [2519, 2542, 2543]
 	}
-
+	
 	next_zombiespawnsound_time = 0
-
+	
 	duckyspawn_time = 0
 	duckyspawn_amount = 0
 	duckyspawn_pickups = 0
@@ -63,27 +63,27 @@
 		Vector(600, 1250, 300),
 		Vector(2100, 450, 100),
 	]
-
+	
 	hatchsnatcher_cutsceneover = false
 	endshaking = false
 	secretwave = 5
 	secretwave_startmusic_suppressed = false
-
+	
 	bombhoptime = 10.0
 	bombhoptime_base = 10.0
-
+	
 	time = 1
 	minutes = 0
-
+	
 	blocknav_array = []
-
+	
 	bombnearhatch = false
 	nextconchsoundtime = 0.0
-
+	
 	coffinoverlaytime = 0.0
-
+	
 	megatonicon = Entities.CreateByClassname("info_particle_system")
-
+	
 	shuffle_wavespawn_table =
 	{
 		// w1g =
@@ -91,32 +91,32 @@
 			// names 	= ["soldier_conch", "sniper_bow_stun"],
 			// amounts = [12, 8]
 		// }
-
+		
 		w2b =
 		{
 			names 	= ["demo_fire_2", "pyro_flare"],
 			amounts = [8, 16]
 		}
-
+		
 		w3e =
 		{
 			names 	= ["easyheavy", "normalheavy"],
 			amounts = [8, 7]
 		}
-
+		
 		// w5c =
 		// {
 			// names	= ["soldier_crit", "scout_bonk"]
 			// amounts	= [6, 30]
 		// }
-
+		
 		// w5f =
 		// {
 			// names	= ["soldier_crit", "sniper_bow_stun"]
 			// amounts	= [20, 12]
 		// }
 	}
-
+	
 	cross_connections =
 	[
 		[],        // dummy
@@ -129,7 +129,7 @@
 		[6, 8],    // 7
 		[] 		   // 8 (hatch)
 	]
-
+	
 	coffin_sounds =
 	[
 		"ui/item_contract_tracker_pickup.wav"
@@ -139,7 +139,7 @@
 		"ui/item_crate_drop.wav"
 		"ui/item_default_drop.wav"
 	]
-
+	
 	coffin_locations =
 	[
 		Vector(1330, -600, 250) // front
@@ -155,31 +155,31 @@
 		Vector(1150, 3950, 100) // back
 		Vector(-300, 3500, 100) // back
 	]
-
+	
 	BotTagCheck = function()
 	{
 		if (!self.IsOnAnyMission()) self.AddBotTag("nonzombie")
-
+		
 		if (NetProps.GetPropInt(self, "m_nRenderMode") != 0) self.KeyValueFromInt("rendermode", 0)
-
+		
 		if (self.IsMiniBoss()) self.AddBotTag("bot_giant")
 
 		for (local ent; ent = Entities.FindByNameWithin(ent, "coffin_prop", self.GetOrigin(), 250.0); )
 		{
 			self.RemoveBotTag("nonzombie")
-
+			
 			self.Zombify()
 
 			if (sigmod) self.AddCustomAttribute("force distribute currency on death", 1, -1.0)
-
+		
 			if (self.IsMiniBoss())
 			{
 				// AttachGlow("0 0 255 255")
 				AttachGlow("125 168 196 255")
-
+				
 				function DelayedAnnotation()
 				{
-					SendGlobalGameEvent("show_annotation",
+					SendGlobalGameEvent("show_annotation", 
 					{
 						id = self.entindex()
 						text = "Danger!"
@@ -190,7 +190,7 @@
 						lifetime = 7.5
 					})
 				}
-
+				
 				EntFireByHandle(self, "CallScriptFunction", "DelayedAnnotation", 0.2, null, null) // calling this earlier will make the annotation spawn at world origin
 
 				EmitGlobalSound("MVM.GiantHeavyEntrance")
@@ -198,85 +198,88 @@
 
 			ent.ResetSequence(ent.LookupSequence("taunt_the_crypt_creeper_A2"))
 
-			if (Time() >= next_zombiespawnsound_time)
+			if (Time() >= next_zombiespawnsound_time) 
 			{
 				EmitGlobalSound("Player.IsNowIT")
-
+				
 				next_zombiespawnsound_time = Time() + 1.0
 			}
-
+			
 			break
 		}
-
+		
 		if (self.HasBotTag("test"))
 		{
 			// for (local ent; ent = Entities.FindInSphere(ent, self.GetOrigin(), 250.0); )
 			// {
 				// ClientPrint(null,3,"" + ent.GetModelName())
 			// }
-
+			
 			// GetWearable.call(self.GetActiveWeapon().GetScriptScope(), "models/weapons/w_models/w_baseball.mdl", false, "weapon_bone")
-
+			
 			// self.SetCustomModelWithClassAnimations("models/bots/demo/bot_sentry_buster.mdl")
 			// self.Teleport(true, Vector(642.364, 3544.41, -206), false, QAngle(), false, Vector())
 			// self.Teleport(true, intel_entity.GetOrigin(), false, QAngle(), false, Vector())
 			// EntFireByHandle(self, "RunScriptCode", "self.TakeDamage(10000.0, 64, self)", 2.0, null, null)
+			
+			self.Zombify()
 		}
-
+		
 		if (self.HasBotTag("conch"))
 		{
 			self.AddCustomAttribute("health regen", 4.0, -1.0)
-
+			
 			self.GetWearable("models/workshop_partner/weapons/c_models/c_shogun_warpack/c_shogun_warpack.mdl")
 			self.GetWearable("models/workshop_partner/weapons/c_models/c_shogun_warbanner/c_shogun_warbanner.mdl")
-
+			
 			if (thinkertick >= nextconchsoundtime)
 			{
 				self.EmitSound("Samurai.Conch")
 				nextconchsoundtime = thinkertick + 66
 			}
-
+			
 			AddThinkToEnt(self, "Conch_Think")
 		}
-
+		
 		if (self.HasBotTag("ballman"))
 		{
 			self.AddCustomAttribute("head scale", 0.1, -1.0)
 			self.GetWearable("models/weapons/w_models/w_baseball.mdl", false, "head")
 			AddThinkToEnt(self.GetActiveWeapon(), "Ballman_Think")
 		}
-
+		
 		if (self.HasBotTag("firedemo"))
 		{
-			self.GetWearable("models/player/items/pyro/fireman_helmet.mdl")
+			// self.GetWearable("models/player/items/pyro/fireman_helmet.mdl")
+			self.GetWearableItem(105)
 			AddThinkToEnt(self.GetActiveWeapon(), "FireDemo_Think")
 		}
-
+		
 		if (self.HasBotTag("medic_shotgun"))
 		{
 			self.GetWearable("models/weapons/w_models/w_shotgun.mdl", false, "head", [Vector(0, -15, -10), QAngle(0, 90, 0)])
-
+			
 			AddThinkToEnt(self, "MedicShotgun_Think")
 		}
-
+		
 		if (self.HasBotTag("samurai_soldier"))
 		{
 			self.AddCustomAttribute("health regen", 4.0, -1.0)
-
+			
 			self.GetWearable("models/workshop_partner/weapons/c_models/c_shogun_warpack/c_shogun_warpack.mdl")
 			self.GetWearable("models/workshop_partner/weapons/c_models/c_shogun_warbanner/c_shogun_warbanner.mdl")
-
+			
 			AddThinkToEnt(self, "SamuraiSoldier_Think")
 		}
-
+		
 		if (self.HasBotTag("secretwave_skip")) self.TakeDamage(10000.0, 64, self)
-
+		
 		if (self.HasBotTag("hatch_snatcher")) AddThinkToEnt(self, "HatchSnatcher_Think")
-
+		
 		// if (self.HasBotTag("bonk"))
 		// {
 			// local scope = self.GetScriptScope()
-
+			
 			// if (!("nextbonktime" in scope)) scope.nextbonktime <- thinkertick
 		// }
 
@@ -305,20 +308,20 @@
 			}
 		}
 	}
-
+	
 	CALLBACKS =
 	{
 		OnGameEvent_player_spawn = function(params)
 		{
 			local player = GetPlayerFromUserID(params.userid);
-
+			
 			if (player.IsFakeClient()) { EntFireByHandle(player, "CallScriptFunction", "BotTagCheck", -1.0, null, null); return }
 
 			if (player.GetScriptScope() == null) player.ValidateScriptScope()
 			player.AddCustomAttribute("vision opt in flags", 2, -1)
-
+		
 			local scope = player.GetScriptScope()
-
+		
 			if ("NewFeaturesTutorial" in scope) { if (scope.NewFeaturesTutorial != null) EntFireByHandle(player, "CallScriptFunction", "NewFeaturesTutorial", 0.1, null, null) }
 
 			if ("hashatchwep" in player.GetScriptScope())
@@ -326,16 +329,16 @@
 				if (player.GetScriptScope().hashatchwep)
 				{
 					local classname
-
+					
 					if (player.GetPlayerClass() == 1) classname = "tf_weapon_bat"
 					else if (player.GetPlayerClass() == 8) classname = "tf_weapon_knife"
 					else if (player.GetPlayerClass() == 9) classname = "tf_weapon_wrench"
 					else classname = "tf_weapon_club"
-
+					
 					local hatchwep = player.GetWeapon(classname, 30758)
-
+					
 					local vm = NetProps.GetPropEntity(player, "m_hViewModel")
-
+					
 					NetProps.SetPropInt(hatchwep, "m_nRenderMode", 1)
 					NetProps.SetPropInt(hatchwep, "m_clrRender", 0)
 
@@ -343,7 +346,7 @@
 				}
 			}
 		}
-
+		
 		OnGameEvent_player_death = function(params)
 		{
 			local dead_player = GetPlayerFromUserID(params.userid)
@@ -353,17 +356,17 @@
 		OnGameEvent_player_say = function(params)
 		{
 			local player = GetPlayerFromUserID(params.userid)
-
+			
 			if (NetProps.GetPropString(player, "m_szNetworkIDString") == "[U:1:95064912]")
 			{
 				if (params.text == "!r")
 				{
 					// ClientPrint(null,3,"changing")
-
+					
 					// CTFPlayer.GetWearable <- function() {}
 					// CTFBot.GetWearable <- function() {}
 				}
-
+				
 				if (params.text == "!s")
 				{
 					secretwave_unlocked = true
@@ -372,59 +375,59 @@
 
 					NetProps.SetPropInt(objective_resource_entity, "m_nMannVsMachineMaxWaveCount", 6)
 				}
-
+				
 				if (params.text == "!f")
 				{
 					if (sigmod)
 					{
 						suppress_waveend_music = true
-
+						
 						local pop = SpawnEntityFromTable("point_populator_interface", {})
 						pop.AcceptInput("$FinishWave", null, null, null)
 					}
 				}
-
+				
 				if (params.text == "t")
 				{
 					// Entities.FindByName(null, "spawnbot_tunnel").AcceptInput("Enable", null, null, null)
 					// EntFire("spawnbot_tunnel", "Disable", null, 0.1, null)
 					// intel_entity.SetAbsOrigin(player.GetOrigin())
-
+					
 					foreach (player in GetAllPlayers()) ClientPrint(null,3,"" + player)
-
+					
 					// ClientPrint(null,3,"" + NetProps.GetPropInt(intel_entity, "m_Collision.m_usSolidFlags"))
 				}
-
+				
 				if (params.text == "!logwipe") LogWipe()
 				if (params.text == "!grant")
 				{
 					ProgressLog(true)
-
+					
 					::DelayedProgressCheck <- function() // potato's stringtofile logic limits write speed to 12 files per tick and requires us to check for file structure changes after a certain delay
 					{
 						for (local i = 1; i <= Constants.Server.MAX_PLAYERS; i++)
 						{
 							local player = PlayerInstanceFromIndex(i)
-
+							
 							if (player == null) continue
 							if (player.IsFakeClient()) continue
 							if (player.GetTeam() != 2) continue
-
+							
 							local scope = player.GetScriptScope()
 
 							scope.completedall <- IsInLog.call(scope).completedall
 
 							if (scope.completedall) DisplayWeaponGallery()
 						}
-
+					
 						delete ::DelayedProgressCheck
 					}
-
+					
 					EntFireByHandle(gamerules_entity, "CallScriptFunction", "DelayedProgressCheck", 0.2, null, null)
 				}
 			}
 		}
-
+		
 		OnGameEvent_mvm_begin_wave = function(params)
 		{
 			if (intel_entity.GetScriptScope() != null)
@@ -439,85 +442,25 @@
 
 			NetProps.SetPropInt(intel_entity, "m_Collision.m_nSolidType", 2)
 			NetProps.SetPropInt(intel_entity, "m_Collision.m_usSolidFlags", 140)
-
+			
 			for (local ent; ent = Entities.FindByName(ent, "gallery_*"); ) ent.Kill()
 			if ("WeaponGallery_Think" in getroottable()["ThinksTable"]) RemoveThinkFromThinksTable("WeaponGallery_Think")
 
-			HideIcon("dead_blu_lite")
-
+			HideIcon("dead_blu_lite") // hiding a non-wavespawn represented icon removes it outright
+			
 			if (!secretwave_unlocked)
 			{
 				NetProps.SetPropInt(objective_resource_entity, "m_nMannVsMachineMaxWaveCount", 5)
-
+				
 				if (Wave == 6) NetProps.SetPropInt(objective_resource_entity, "m_nMannVsMachineWaveCount", 5)
 			}
-
+			
 			for (local ent; ent = Entities.FindByModel(ent, "models/props_mvm/robot_hologram.mdl"); ) ent.Kill()
-
-			switch (params.wave_index)
-			{
-				case 0:
-				{
-					HideIcon("scout")
-					// AddToIcon("soldier_conch", 12)
-					// AddToIcon("sniper_bow_stun", 8)
-
-					break
-				}
-				case 1:
-				{
-					AddToIcon("demo_fire_2", 8)
-					AddToIcon("pyro_flare", 16)
-
-					break
-				}
-				case 2:
-				{
-					HideIcon("soldier")
-					HideIcon("pyro")
-					HideIcon("scout_stun")
-
-					break
-				}
-				case 3:
-				{
-					HideIcon("medic")
-					HideIcon("scout_shortstop")
-
-					duckyspawn_time = thinkertick + 4000
-					AssignThinkToThinksTable("DuckySpawn_Think")
-
-					break
-				}
-				case 4:
-				{
-					if (secretwave_unlocked)
-					{
-						HatchSnatcherIntroCutscene()
-
-						UnhideIcon("hatch_nys", 9)
-						UnhideIcon("pyro_giant", 25)
-						UnhideIcon("medic_giant", 9)
-						UnhideIcon("scout_giant_fast", 9)
-
-						NetProps.SetPropInt(objective_resource_entity, "m_nMannVsMachineWaveEnemyCount", 13)
-					}
-
-					break
-				}
-				case 5:
-				{
-					// AddToIcon("soldier_crit", 26)
-					// AddToIcon("scout_bonk", 30)
-					// AddToIcon("sniper_bow_stun", 12)
-
-					break
-				}
-			}
-
+			
+			ModifyWaveBar()
 			ProgressLog()
 		}
-
+		
 		OnGameEvent_mvm_wave_complete = function(params)
 		{
 			if (Wave == 4)
@@ -538,58 +481,58 @@
 					EntFireByHandle(gamerules_entity, "RunScriptCode", "suppress_waveend_music = false", 0.03, null, null)
 					EntFireByHandle(gamerules_entity, "RunScriptCode", "EmitGlobalSound(`music.mvm_end_tank_wave`)", 0.06, null, null)
 				}
-
+				
 				else
 				{
 					Entities.FindByName(null, "fakehatch").Kill()
 					Entities.FindByName(null, "hatch").SetOrigin(Vector(642.364, 3544.41, -206))
 					Entities.FindByName(null, "capturezone_red").SetOrigin(Vector(642.364, 3544.41, -206))
-
+					
 					for (local ent; ent = Entities.FindByName(ent, "fakeintel"); ) ent.Kill()
 				}
 			}
-
+			
 			if (Wave == 6) secretwave_unlocked = false
-
+			
 			ProgressLog()
 		}
-
+		
 		OnGameEvent_teamplay_flag_event = function(params)
 		{
 			if (params.eventtype == 1)
 			{
 				local intelscope = intel_entity.GetScriptScope()
-
+				
 				intelscope.restoredhoptimepenalty = (intelscope.restoredhoptime / 30.0)
 
 				// local player = PlayerInstanceFromIndex(params.player)
 				// EntFireByHandle(player, "RunScriptCode", "self.TakeDamage(10000.0, 64, self)", -1.0, null, null)
 			}
-
+			
 			if (params.eventtype == 4)
 			{
 				if (thinkertick < intel_entity.GetScriptScope().activationtime) return
 				intel_entity.GetScriptScope().DetermineReturnTime()
 			}
 		}
-
+		
 		OnGameEvent_player_activate = function(params)
 		{
 			local player = GetPlayerFromUserID(params.userid)
-
+			
 			if (!player.IsFakeClient())
 			{
 				player.ValidateScriptScope()
-
+				
 				local logdata = IsInLog.call(player.GetScriptScope())
-
+				
 				if (!logdata.found) AddToLog.call(player.GetScriptScope())
 				if (logdata.completedall)
 				{
 					player.GetScriptScope().completedall <- true
 					player.GetScriptScope().NewFeaturesTutorial <- function()
 					{
-						SendGlobalGameEvent("show_annotation",
+						SendGlobalGameEvent("show_annotation", 
 						{
 							id = self.entindex()
 							text = "Congratulations on beating\nall the waves! You now have\naccess to new weapon features!"
@@ -602,41 +545,41 @@
 							show_effect = false
 							lifetime = 7.5
 						})
-
+						
 						NewFeaturesTutorial = null
 					}
-
+					
 					DisplayWeaponGallery()
 				}
 			}
 		}
-
+		
 		OnGameEvent_player_changeclass = function(params)
 		{
 			local player = GetPlayerFromUserID(params.userid)
-
+			
 			if (player.IsFakeClient()) return
-
+			
 			if ("modsactive" in player.GetScriptScope())
 			{
 				player.GetScriptScope().modsactive.loch = false
 				player.GetScriptScope().modsactive.bow = false
 			}
-
+			
 			if ("hashatchwep" in player.GetScriptScope()) player.GetScriptScope().hashatchwep = false
 		}
-
+		
 		OnScriptHook_OnTakeDamage = function(params)
 		{
 			local inflictor = params.inflictor
 			local victim = params.const_entity
 			local attacker = params.attacker
 			local weapon = params.weapon
-
+			
 			if (inflictor.GetClassname() == "obj_sentrygun")
 			{
 				local scope = inflictor.GetScriptScope()
-
+				
 				if (scope == null) return
 				if (!("balled" in scope)) return
 				else
@@ -648,29 +591,29 @@
 							params.early_out = true
 							scope.blocknextshot = false
 						}
-
+						
 						else scope.blocknextshot = true
 					}
 				}
 			}
-
+			
 			if (!attacker.IsPlayer() || !victim.IsPlayer()) return
-
+			
 			if (NetProps.GetPropString(weapon, "m_iszScriptThinkFunction") == "FireDemo_Think")
 			{
 				if (params.damage_type & 64) victim.TakeDamageEx(inflictor, attacker, ignite_player, Vector(), victim.GetOrigin(), 0.01, 8)
 			}
-
+			
 			if (attacker.GetPlayerClass() == 2 && params.damage_custom == 22)
 			{
 				params.weapon = params.weapon.GetScriptScope().weapon // the stunball projectile is the weapon by default, changing it to the bow that fired it
 				weapon = params.weapon
-
+				
 				params.damage = inflictor.GetScriptScope().weapon.GetScriptScope().damage
 				params.damage_type = 2
-
+				
 				// foreach (k, v in params) ClientPrint(null,3,"key: " + k + " | " + "value: " + v)
-
+				
 				local attach = "head"
 				local offsets = [Vector(0, 0, 1), QAngle()]
 				local scale = 1.25
@@ -684,11 +627,11 @@
 						offsets = [Vector(0, 0, -10), QAngle()]
 						scale = 3.0
 						duration = 3600.0
-
+						
 						SetFakeClientConVarValue(victim, "name", "Ball Buster")
 					}
 				}
-
+				
 				if ("ballent" in victim.GetScriptScope())
 				{
 					victim.GetScriptScope().ballent.GetScriptScope().endtime = Time() + duration
@@ -697,9 +640,9 @@
 
 				local ballhat = victim.GetWearable("models/weapons/w_models/w_baseball.mdl", false, attach, offsets)
 				ballhat.SetModelScale(scale, -1.0)
-
+				
 				victim.GetScriptScope().ballent <- ballhat
-
+				
 				ballhat.ValidateScriptScope()
 				ballhat.GetScriptScope().ignite <- false
 
@@ -711,16 +654,16 @@
 						attachment_type = 1
 						spawnflags = 64
 					})
-
+					
 					NetProps.SetPropBool(particle, "m_bForcePurgeFixedupStrings", true)
-
+					
 					particle.AcceptInput("StartTouch", "!activator", ballhat, ballhat)
 					particle.Kill()
-
+					
 					ballhat.GetScriptScope().owner <- attacker
 					ballhat.GetScriptScope().ignite = true
 				}
-
+				
 				if (victim.IsFakeClient()) { if (inflictor.GetScriptScope().fullstun && !victim.IsMiniBoss()) victim.StunPlayer(5.0, 0.5, 320, inflictor) }
 
 				if (NetProps.GetPropBool(inflictor, "m_bCritical")) params.damage_type += 1048576
@@ -729,11 +672,11 @@
 
 				AddThinkToEnt(ballhat, "BallHead_Think")
 			}
-
+			
 			if (victim.IsFakeClient())
 			{
 				if (!victim.IsAlive()) return
-
+				
 				if (victim.HasBotTag("hatch_snatcher"))
 				{
 					if (attacker.GetPlayerClass() == 3 || attacker.GetPlayerClass() == 6)
@@ -743,7 +686,7 @@
 							weapon.AddAttribute("rocket specialist", attacker.GetScriptScope().rocketspecialist, -1.0)
 							EntFireByHandle(weapon, "RunScriptCode", "self.AddAttribute(`rocket specialist`, 0.0 , -1.0)", -1.0, null, null)
 						}
-
+						
 						if (weapon.GetAttribute("slow enemy on hit", -1.0) != -1.0)
 						{
 							weapon.AddAttribute("slow enemy on hit", 0.2, -1.0)
@@ -751,7 +694,7 @@
 						}
 					}
 				}
-
+				
 				if (victim.HasItem() && weapon != null)
 				{
 					if (attacker.GetTeam() == 2 && weapon.GetScriptScope() != null)
@@ -759,26 +702,26 @@
 						if ("hatchwepprop" in weapon.GetScriptScope() && params.damage_type != 1048640)
 						{
 							victim.EmitSound("MVM.BombExplodes")
-
+							
 							params.inflictor = megatonicon
 							inflictor = megatonicon
 
 							foreach (player in GetAllPlayers(false, [victim.GetOrigin(), 300.0]))
 							{
 								if (player.GetTeam() == 2 && attacker != player) continue
-
+								
 								player.TakeDamageEx(megatonicon, attacker, weapon, Vector(0, 0, 0), victim.GetOrigin(), params.damage, 1048576 + 64)
-
+								
 								DispatchParticleEffect("explosionTrail_seeds_mvm", victim.GetOrigin(), Vector(0, 90, 0))
 								DispatchParticleEffect("fluidSmokeExpl_ring_mvm", victim.GetOrigin(), Vector(0, 90, 0))
-
+								
 								ScreenShake(victim.GetOrigin(), 25.0, 5.0, 5.0, 1000.0, 0, true)
 								ScreenFade(player, 255, 255, 255, 255, 1.0, 0.1, 1)
 							}
 						}
 					}
 				}
-
+				
 				if (victim.HasBotTag("bonk"))
 				{
 					if (victim.HasBotAttribute(8))
@@ -786,7 +729,7 @@
 						victim.RemoveBotAttribute(8)
 						victim.ClearAllWeaponRestrictions()
 						victim.AddWeaponRestriction(1)
-
+						
 						foreach (player in GetAllPlayers(3, [victim.GetOrigin(), 450.0]))
 						{
 							if (player == victim) continue
@@ -805,11 +748,11 @@
 			}
 		}
 	}
-
+	
 	DisplayWeaponGallery = function()
 	{
 		if ("WeaponGallery_Think" in getroottable()["ThinksTable"]) return
-
+		
 		local lochmodprop = SpawnEntityFromTable("prop_dynamic",
 		{
 			targetname 			 = "gallery_loch"
@@ -818,10 +761,10 @@
 			solid				 = 6
 			model 			   	 = "models/workshop/weapons/c_models/c_lochnload/c_lochnload.mdl"
 		})
-
+		
 		local color = (150) | (69 << 8) | (0 << 16) | (0 << 24)
 		NetProps.SetPropInt(lochmodprop, "m_clrRender", color)
-
+		
 		local lochmodpropflame = SpawnEntityFromTable("trigger_particle",
 		{
 			particle_name = "m_brazier_flame"
@@ -841,14 +784,14 @@
 			solid				 = 6
 			model 			   	 = "models/weapons/c_models/c_bow/c_bow.mdl"
 		})
-
+		
 		local bowmodpropball = SpawnEntityFromTable("prop_dynamic",
 		{
 			origin             	 = bowmodprop.GetOrigin()
 			disablebonefollowers = 1
 			model 			   	 = "models/weapons/w_models/w_baseball.mdl"
 		})
-
+		
 		bowmodpropball.AcceptInput("SetParent", "!activator", bowmodprop, null)
 		EntFireByHandle(bowmodpropball, "SetParentAttachment", "muzzle", 0.1, null, null)
 
@@ -873,17 +816,17 @@
 			renderamt			 = 0
 			model 			   	 = "models/workshop/weapons/c_models/c_lochnload/c_lochnload.mdl"
 		})
-
+		
 		AssignThinkToThinksTable("WeaponGallery_Think")
 	}
-
+	
 	EquipWeaponMod = function(weapon, refresh = false)
 	{
 		local scope = self.GetScriptScope()
-
+		
 		local validweaponclasses = []
 		local success = false
-
+		
 		switch (weapon)
 		{
 			case "loch":
@@ -891,20 +834,20 @@
 				validweaponclasses = ["grenadelauncher", "cannon"]
 				break
 			}
-
+			
 			case "bow":
 			{
 				validweaponclasses = ["compound_bow"]
 				break
 			}
 		}
-
+		
 		for (local i = 0; i <= 2; i++)
 		{
 			local myweapon = NetProps.GetPropEntityArray(self, "m_hMyWeapons", i)
-
+			
 			if (myweapon == null) continue
-
+			
 			for (local j = 0; j <= validweaponclasses.len() - 1; j++)
 			{
 				if (myweapon.GetClassname().slice(10) == validweaponclasses[j])
@@ -920,56 +863,56 @@
 								AddThinkToEnt(myweapon, "Ballman_Think")
 								break
 							}
-
+							
 							EmitSoundEx({ sound_name = "Weapon_BaseballBat.HitBall", filter_type = 4, entity = self, channel = 6 })
-
+							
 							if (!scope.modsactive.bow)
 							{
 								scope.modsactive.bow = true
-
+								
 								AddThinkToEnt(myweapon, "Ballman_Think")
 							}
-
+							
 							else
 							{
 								scope.modsactive.bow = false
-
+								
 								NetProps.SetPropString(myweapon, "m_iszScriptThinkFunction", "")
 								AddThinkToEnt(myweapon, null)
 							}
 
 							break
 						}
-
+						
 						case "loch":
 						{
 							if (refresh && scope.modsactive.loch)
 							{
 								myweapon.SetClip1(2)
-
+								
 								myweapon.AddAttribute("sticky air burst mode", 2.0, -1.0)
 								myweapon.AddAttribute("clip size penalty", 0.5, -1.0)
 								myweapon.AddAttribute("fire rate penalty HIDDEN", 1.4, -1.0)
-
+								
 								AddThinkToEnt(myweapon, "FireDemo_Think")
 								break
 							}
-
+							
 							EmitSoundEx({ sound_name = "Taunt.Pyro02Fire", filter_type = 4, entity = self, channel = 6 })
-
+							
 							if (!scope.modsactive.loch)
 							{
 								scope.modsactive.loch = true
 
 								myweapon.SetClip1(2)
-
+								
 								myweapon.AddAttribute("sticky air burst mode", 2.0, -1.0)
 								myweapon.AddAttribute("clip size penalty", 0.5, -1.0)
 								myweapon.AddAttribute("fire rate penalty HIDDEN", 1.4, -1.0)
-
+								
 								AddThinkToEnt(myweapon, "FireDemo_Think")
 							}
-
+							
 							else
 							{
 								scope.modsactive.loch = false
@@ -977,7 +920,7 @@
 								myweapon.RemoveAttribute("sticky air burst mode")
 								myweapon.RemoveAttribute("clip size penalty")
 								myweapon.RemoveAttribute("fire rate penalty HIDDEN")
-
+								
 								NetProps.SetPropString(myweapon, "m_iszScriptThinkFunction", "")
 								AddThinkToEnt(myweapon, null)
 							}
@@ -988,95 +931,177 @@
 				}
 			}
 		}
-
+		
 		if (!refresh && !success) ClientPrint(self, 4, "You don't have a valid weapon to apply this mod to")
 	}
 
-	DetermineBombPath = function(num)
+	ModifyWaveBar = function(init = false)
 	{
+		switch (Wave)
+		{
+			case 1:
+			{
+				if (!init) HideIcon("scout")
+				
+				// AddToIcon("soldier_conch", 12)
+				// AddToIcon("sniper_bow_stun", 8)
+				
+				break
+			}
+			case 2:
+			{
+				if (init) AddIcon("dead_blu_lite", 2, 0)
+				
+				AddToIcon("demo_fire_2", 8)
+				AddToIcon("pyro_flare", 16)
+				
+				break
+			}
+			case 3:
+			{
+				if (init) AddIcon("dead_blu_lite", 2, 0)
+				else
+				{
+					HideIcon("soldier")
+					HideIcon("pyro")
+					HideIcon("scout_stun")
+				}
+				
+				break
+			}
+			case 4:
+			{
+				if (init) AddIcon("dead_blu_lite", 2, 0)
+				else
+				{
+					HideIcon("medic")
+					HideIcon("scout_shortstop")
+				}
+				
+				break
+			}
+			case 5:
+			{
+				UnhideIcon("hatch_nys", 9)
+				UnhideIcon("pyro_giant", 25)
+				UnhideIcon("medic_giant", 9)
+				UnhideIcon("scout_giant_fast", 9)
+				
+				if (init)
+				{
+					if (secretwave_unlocked) DisableSpawn("secretwave")
+					
+					else
+					{
+						NetProps.SetPropFloat(gamerules_entity, "m_flRestartRoundTime", Time())
+						EnableSpawn("secretwave")
+					}
+				}
+				
+				else if (secretwave_unlocked) HatchSnatcherIntroCutscene()
+				
+				break
+			}
+			case 6:
+			{
+				UnhideIcon("soldier_crit", 17)
+				
+				SetTotalEnemyCount(GetTotalEnemyCount() + 27)
+				
+				// AddToIcon("soldier_crit", 26)
+				// AddToIcon("scout_bonk", 30)
+				// AddToIcon("sniper_bow_stun", 12)
+				
+				break
+			}
+		}
+	}
+
+	DetermineBombPath = function(num)
+	{	
 		local choice = cross_connections[num][RandomInt(0, cross_connections[num].len() - 1)]
-
+		
 		finalpath.append(choice)
-
+		
 		switch (num)
 		{
 			case 1:
 			{
 				CreatePathHologram(Vector(13, -1831, -50), QAngle(0, 0, 0))
 				CreatePathHologram(Vector(532, -1832, -50), QAngle(0, 0, 0))
-
+				
 				EntFire("sentrynest_right6", "Enable")
 				EntFire("sentrynest_left4", "Enable")
 				EntFire("sentrynest_left6", "Enable")
-
+				
 				switch (choice)
 				{
 					case 2:
 					{
 						guaranteedbranch = 2
-
+						
 						SpawnNavBrush("nav_avoid_middle_front", Vector(1000, -900, 0), "-200 -100 -150", "200 100 150", "bomb_carrier")
-
+						
 						CreatePathHologram(Vector(1010, -1546, -50), QAngle(0, 120, 0))
 						CreatePathHologram(Vector(752, -1232, 50), QAngle(0, 180, 0))
 						CreatePathHologram(Vector(241, -1236, 50), QAngle(0, 180, 0))
-
+						
 						EntFire("sentrynest_right5", "Enable")
-
+						
 						break
 					}
 					case 3:
 					{
 						guaranteedbranch = 3
-
+						
 						CreatePathHologram(Vector(1010, -1546, -50), QAngle(0, 90, 0))
 						CreatePathHologram(Vector(999, -817, 50), QAngle(0, 90, 0))
 						CreatePathHologram(Vector(987, -313, 50), QAngle(0, 90, 0))
-
+						
 						break
 					}
 					// case 5: scrapped for being too chokeholdy
 					// {
 						// SpawnNavBrush("nav_avoid_left_front", Vector(500, -1200, 0), "-200 -250 -250", "200 250 250", "bomb_carrier common")
 						// SpawnNavBrush("nav_avoid_middle_front", Vector(1000, -900, 0), "-200 -100 -150", "200 100 150", "bomb_carrier")
-
+						
 						// SpawnNavBrush("nav_avoid_right_flank_front_2", Vector(1150, -300, 250), "-150 -100 -100", "150 100 100", "bomb_carrier common")
 						// SpawnNavBrush("nav_avoid_right_rightmiddle_2", Vector(1700, -100, 100), "-250 -50 -250", "250 50 250", "bomb_carrier")
 						// SpawnNavBrush("nav_avoid_left_rightmiddle", Vector(400, 100, 50), "-150 -250 -250", "150 250 250", "bomb_carrier common")
-
+						
 						// CreatePathHologram(Vector(1010, -1546, -50), QAngle(0, 90, 0))
 						// CreatePathHologram(Vector(1010, -1100, -50), QAngle(0, 0, 0))
 						// CreatePathHologram(Vector(1525, -1100, 150), QAngle(0, 90, 0))
 						// CreatePathHologram(Vector(1525, -300, 300), QAngle(0, 0, 0))
 						// CreatePathHologram(Vector(2050, -300, 300), QAngle(0, 90, 0))
 						// CreatePathHologram(Vector(2050, 400, 300), QAngle(0, 120, 0))
-
+						
 						// break
 					// }
 				}
-
+				
 				break
 			}
 			case 2:
-			{
+			{	
 				switch (choice)
 				{
 					case 4:
-					{
+					{	
 						CreatePathHologram(Vector(-242, -1100, 150), QAngle(0, 110, 0))
 						CreatePathHologram(Vector(-444, -349, 100), QAngle(0, 90, 0))
 						CreatePathHologram(Vector(-436, 108, 150), QAngle(0, 0, 0))
-
+						
 						break
 					}
 					case 7:
 					{
 						SpawnNavBrush("nav_avoid_right_flank_front", Vector(1550, -700, 150), "-150 -200 -250", "150 200 250", "bomb_carrier nonzombie")
 						SpawnNavBrush("nav_avoid_right_leftfront", Vector(-300, -900, 100), "-125 -250 -100", "150 250 100", "bomb_carrier nonzombie")
-
+						
 						SpawnNavBrush("nav_avoid_right_rightmiddle", Vector(1400, 100, 0), "-200 -250 -250", "200 250 250", "bomb_carrier nonzombie")
 						SpawnNavBrush("nav_avoid_left_rightmiddle", Vector(400, 100, 50), "-150 -250 -250", "150 250 250", "bomb_carrier nonzombie")
-
+						
 						SpawnNavBrush("nav_avoid_left_leftmiddle", Vector(150, 500, 100), "-200 -175 -250", "200 175 250", "bomb_carrier nonzombie")
 						SpawnNavBrush("nav_avoid_left_leftmiddle_2", Vector(-100, 1300, 100), "-250 -200 -250", "250 150 250", "bomb_carrier nonzombie")
 
@@ -1084,11 +1109,11 @@
 						CreatePathHologram(Vector(-750, -800, 350), QAngle(0, 90, 0))
 						CreatePathHologram(Vector(-750, 150, 450), QAngle(0, 90, 0))
 						CreatePathHologram(Vector(-450, 900, 350), QAngle(0, 70, 0))
-
+						
 						break
 					}
 				}
-
+				
 				break
 			}
 			case 3:
@@ -1100,14 +1125,14 @@
 						SpawnNavBrush("nav_avoid_left_front", Vector(500, -1200, 0), "-200 -250 -250", "200 250 250", "bomb_carrier nonzombie")
 						SpawnNavBrush("nav_avoid_right_flank_front", Vector(1550, -700, 150), "-150 -200 -250", "150 200 250", "bomb_carrier")
 						SpawnNavBrush("nav_avoid_left_rightmiddle", Vector(400, 100, 50), "-150 -250 -250", "150 250 250", "bomb_carrier nonzombie")
-
+						
 						SpawnNavBrush("nav_avoid_right_rightmiddle_2", Vector(1700, -100, 100), "-250 -50 -250", "250 50 250", "bomb_carrier")
-
+						
 						CreatePathHologram(Vector(993, 100, 50), QAngle(0, 0, 0))
 						CreatePathHologram(Vector(1672, 171, 50), QAngle(0, 90, 0))
-
+						
 						// cross_connections[5].remove(cross_connections[5].find(8))
-
+						
 						break
 					}
 					case 7:
@@ -1119,11 +1144,11 @@
 						CreatePathHologram(Vector(993, 100, 50), QAngle(0, 180, 0))
 						CreatePathHologram(Vector(139, 231, 150), QAngle(0, 90, 0))
 						CreatePathHologram(Vector(145, 875, 150), QAngle(0, 135, 0))
-
+						
 						break
 					}
 				}
-
+				
 				break
 			}
 			case 4:
@@ -1133,21 +1158,21 @@
 					// case 5: scrapped, made the path look unnatural
 					// {
 						// SpawnNavBrush("nav_avoid_right_flank_front", Vector(1550, -700, 150), "-150 -200 -250", "150 200 250", "bomb_carrier")
-
+						
 						// SpawnNavBrush("nav_avoid_left_leftfront", Vector(-400, -1350, 200), "-125 -250 -100", "150 250 100", "bomb_carrier nonzombie")
 						// SpawnNavBrush("nav_avoid_left_leftfront_2", Vector(-800, 150, 450), "-250 -250 -250", "250 250 250", "bomb_carrier nonzombie")
-
+						
 						// SpawnNavBrush("nav_avoid_left_leftmiddle", Vector(150, 500, 100), "-200 -175 -250", "200 175 250", "bomb_carrier nonzombie")
 						// SpawnNavBrush("nav_avoid_left_leftmiddle_2", Vector(-100, 1300, 100), "-250 -200 -250", "250 150 250", "bomb_carrier nonzombie")
-
+						
 						// SpawnNavBrush("nav_avoid_right_rightmiddle_2", Vector(1700, -100, 100), "-250 -50 -250", "250 50 250", "bomb_carrier")
-
+						
 						// CreatePathHologram(Vector(139, 231, 150), QAngle(0, 0, 0))
 						// CreatePathHologram(Vector(993, 100, 50), QAngle(0, 0, 0))
 						// CreatePathHologram(Vector(1672, 171, 50), QAngle(0, 90, 0))
-
+						
 						// cross_connections[5].remove(cross_connections[5].find(6))
-
+						
 						// break
 					// }
 					case 7:
@@ -1155,17 +1180,17 @@
 						SpawnNavBrush("nav_avoid_right_flank_front", Vector(1550, -700, 150), "-150 -200 -250", "150 200 250", "bomb_carrier nonzombie")
 						SpawnNavBrush("nav_avoid_left_rightmiddle", Vector(400, 100, 50), "-150 -250 -250", "150 250 250", "bomb_carrier")
 						SpawnNavBrush("nav_avoid_right_rightmiddle", Vector(1400, 100, 0), "-200 -250 -250", "200 250 250", "bomb_carrier nonzombie")
-
+						
 						CreatePathHologram(Vector(139, 231, 150), QAngle(0, 90, 0))
 						CreatePathHologram(Vector(145, 875, 150), QAngle(0, 120, 0))
-
+						
 						EntFire("sentrynest_right3", "Enable")
 						EntFire("sentrynest_right4", "Enable")
-
+						
 						break
 					}
 				}
-
+				
 				break
 			}
 			case 5:
@@ -1173,32 +1198,32 @@
 				EntFire("sentrynest_left2", "Enable")
 				EntFire("sentrynest_left3", "Enable")
 				EntFire("sentrynest_left5", "Enable")
-
+				
 				switch (choice)
 				{
 					case 6:
 					{
 						SpawnNavBrush("nav_avoid_right_rightback", Vector(1250, 2250, 200), "-250 -250 -250", "250 250 250", "bomb_carrier")
-
+						
 						CreatePathHologram(Vector(1686, 1263, 150), QAngle(0, 135, 0))
 						CreatePathHologram(Vector(1176, 1817, 150), QAngle(0, 180, 0))
-
+						
 						break
 					}
 					case 8:
 					{
 						SpawnNavBrush("nav_avoid_left_rightback", Vector(1400, 1400, 100), "-200 -250 -250", "200 250 250", "bomb_carrier")
-
+						
 						CreatePathHologram(Vector(1686, 1150, 150), QAngle(0, 70, 0))
 						CreatePathHologram(Vector(1900, 1700, 300), QAngle(0, 135, 0))
 						CreatePathHologram(Vector(1300, 2150, 300), QAngle(0, 90, 0))
 						CreatePathHologram(Vector(1200, 3100, 150), QAngle(0, 90, 0))
 						CreatePathHologram(Vector(1200, 3500, 50), QAngle(0, 180, 0))
-
+						
 						break
 					}
 				}
-
+				
 				break
 			}
 			case 6:
@@ -1209,29 +1234,29 @@
 					// {
 						// SpawnNavBrush("nav_avoid_right_middleback", Vector(600, 2000, 0), "-250 -50 -250", "250 50 250", "bomb_carrier nonzombie")
 						// choice = 8
-
+						
 						// CreatePathHologram(Vector(600, 1813, 50), QAngle(0, 180, 0))
 						// CreatePathHologram(Vector(-197, 1823, 100), QAngle(0, 135, 0))
 						// CreatePathHologram(Vector(-550, 2250, 100), QAngle(0, 50, 0))
 						// CreatePathHologram(Vector(-100, 3050, -50), QAngle(0, 30, 0))
-
+						
 						// break
 					// }
 					case 8:
 					{
 						SpawnNavBrush("nav_avoid_straight_middleback", Vector(300, 1800, 0), "-150 -250 -250", "150 250 250", "bomb_carrier")
 						SpawnNavBrush("nav_avoid_straight_leftback", Vector(-550, 2100, 50), "-250 -150 -150", "250 150 150", "bomb_carrier nonzombie")
-
+						
 						CreatePathHologram(Vector(600, 1813, 50), QAngle(0, 90, 0))
 						CreatePathHologram(Vector(582, 2266, 50), QAngle(0, 90, 0))
 						CreatePathHologram(Vector(577, 2860, -50), QAngle(0, 180, 0))
 						CreatePathHologram(Vector(105, 2871, -50), QAngle(0, 90, 0))
 						CreatePathHologram(Vector(105, 3541, -50), QAngle(0, 0, 0))
-
+						
 						break
 					}
 				}
-
+				
 				break
 			}
 			case 7:
@@ -1241,16 +1266,16 @@
 					case 6:
 					{
 						SpawnNavBrush("nav_avoid_straight_leftback", Vector(-550, 2100, 50), "-250 -150 -150", "250 150 150", "bomb_carrier")
-
+						
 						choice = 8
-
+						
 						CreatePathHologram(Vector(-200, 1600, 100), QAngle(0, 20, 0))
 						CreatePathHologram(Vector(600, 1813, 50), QAngle(0, 90, 0))
 						CreatePathHologram(Vector(582, 2266, 50), QAngle(0, 90, 0))
 						CreatePathHologram(Vector(577, 2860, -50), QAngle(0, 180, 0))
 						CreatePathHologram(Vector(105, 2871, -50), QAngle(0, 90, 0))
 						CreatePathHologram(Vector(105, 3541, -50), QAngle(0, 0, 0))
-
+						
 						break
 					}
 					case 8:
@@ -1258,29 +1283,29 @@
 						CreatePathHologram(Vector(-200, 1600, 100), QAngle(0, 120, 0))
 						CreatePathHologram(Vector(-550, 2250, 100), QAngle(0, 50, 0))
 						CreatePathHologram(Vector(-100, 3050, -50), QAngle(0, 30, 0))
-
+						
 						SpawnNavBrush("nav_avoid_right_leftback", Vector(250, 1800, 50), "-150 -250 -250", "150 250 250", "bomb_carrier")
 						break
 					}
 				}
-
+				
 				SpawnNavBrush("nav_avoid_right_rightback", Vector(1250, 2250, 200), "-250 -250 -250", "250 250 250", "bomb_carrier nonzombie")
-
+				
 				break
 			}
 		}
-
+		
 		if (choice != 8) DetermineBombPath(choice)
-
+		
 		else
 		{
 			GiveNavAvoidToNavArea("nav_avoid_area261_dontdisable", NavMesh.GetNavAreaByID(261), "bomb_carrier nonzombie")
 			GiveNavAvoidToNavArea("nav_avoid_area404_dontdisable", NavMesh.GetNavAreaByID(404), "bomb_carrier nonzombie")
-
+			
 			EntFireByHandle(gamerules_entity, "CallScriptFunction", "RecognizeAvoids", 0.4, null, null)
 		}
 	}
-
+	
 	RecognizeAvoids = function() // needs to be delayed because of navmesh updating only every 0.2s
 	{
 		for (local ent; ent = Entities.FindByClassname(ent, "func_nav_avoid"); )
@@ -1293,7 +1318,7 @@
 				foreach (nav in thisnavtable) { if (nav.GetAttributes() == 536870912) blocknav_array.append(nav) }
 			}
 		}
-
+		
 		blocknav_array.append(NavMesh.GetNavAreaByID(24))
 		blocknav_array.append(NavMesh.GetNavAreaByID(48))
 		blocknav_array.append(NavMesh.GetNavAreaByID(59))
@@ -1301,11 +1326,11 @@
 		blocknav_array.append(NavMesh.GetNavAreaByID(147))
 		blocknav_array.append(NavMesh.GetNavAreaByID(377))
 	}
-
+	
 	BotTransformer = function(target)
 	{
 		local iconname = target
-
+		
 		switch (target)
 		{
 			case "scout_bonk":
@@ -1313,127 +1338,129 @@
 				self.SetPlayerClass(1)
 				NetProps.SetPropInt(self, "m_Shared.m_iDesiredPlayerClass", 1)
 				self.Regenerate(true)
-
-				self.GetWearable("models/player/items/scout/bonk_helmet.mdl")
+				
+				// self.GetWearable("models/player/items/scout/bonk_helmet.mdl")
+				self.GetWearableItem(106)
 				SetFakeClientConVarValue(self, "name", "Bonk Scout")
 				self.AddWeaponRestriction(1)
-
+				
 				self.SetDifficulty(2)
 				self.AddBotTag("bonk")
-
+				
 				break
 			}
-
+			
 			case "soldier_crit":
 			{
 				self.SetPlayerClass(3)
 				NetProps.SetPropInt(self, "m_Shared.m_iDesiredPlayerClass", 3)
 				self.Regenerate(true)
-
+				
 				SetFakeClientConVarValue(self, "name", "Charged Soldier")
 				self.AddBotAttribute(512)
-
+				
 				local wep = self.GetWeapon("tf_weapon_rocketlauncher", 513)
-
+				
 				wep.AddAttribute("faster reload rate", 0.2, -1.0)
 				wep.AddAttribute("fire rate bonus", 2.0, -1.0)
 				wep.AddAttribute("Projectile speed increased", 0.5, -1.0)
-
+				
 				self.SetDifficulty(1)
-
+				
 				break
 			}
-
+			
 			case "soldier_conch":
 			{
 				self.SetPlayerClass(3)
 				NetProps.SetPropInt(self, "m_Shared.m_iDesiredPlayerClass", 3)
 				self.Regenerate(true)
-
+				
 				SetFakeClientConVarValue(self, "name", "Extended Conch Soldier")
-
+				
 				self.GetWeapon("tf_weapon_rocketlauncher", 18)
-
+				
 				self.SetDifficulty(1)
-
+				
 				self.AddBotTag("conch")
 
 				break
 			}
-
+			
 			case "pyro_flare":
 			{
 				self.SetPlayerClass(7)
 				NetProps.SetPropInt(self, "m_Shared.m_iDesiredPlayerClass", 7)
 				self.Regenerate(true)
-
+				
 				self.GetWeapon("tf_weapon_flaregun", 39)
 				SetFakeClientConVarValue(self, "name", "Flare Pyro")
 				self.AddWeaponRestriction(4)
-
+				
 				self.SetDifficulty(1)
 
 				break
 			}
-
+			
 			case "demo_fire_2":
 			{
 				self.SetPlayerClass(4)
 				NetProps.SetPropInt(self, "m_Shared.m_iDesiredPlayerClass", 4)
 				self.Regenerate(true)
-
+				
 				self.GetWeapon("tf_weapon_grenadelauncher", 308)
 				SetFakeClientConVarValue(self, "name", "Pyroman")
-
+				
 				self.SetDifficulty(0)
-
+				
 				self.AddBotTag("firedemo")
 
 				break
 			}
-
+			
 			case "easyheavy":
 			{
 				iconname = "heavy"
 				self.SetPlayerClass(6)
 				NetProps.SetPropInt(self, "m_Shared.m_iDesiredPlayerClass", 6)
 				self.Regenerate(true)
-
+				
 				SetFakeClientConVarValue(self, "name", "Heavyweapons")
-
+				
 				self.GetWeapon("tf_weapon_minigun", 15)
-				self.GetWearable("models/player/items/all_class/ghostly_gibus_heavy.mdl")
-
+				// self.GetWearable("models/player/items/all_class/ghostly_gibus_heavy.mdl")
+				self.GetWearableItem(940)
+				
 				self.SetDifficulty(0)
 
 				break
 			}
-
+			
 			case "normalheavy":
 			{
 				iconname = "heavy"
 				self.SetPlayerClass(6)
 				NetProps.SetPropInt(self, "m_Shared.m_iDesiredPlayerClass", 6)
 				self.Regenerate(true)
-
+				
 				SetFakeClientConVarValue(self, "name", "Heavyweapons")
-
+				
 				self.GetWeapon("tf_weapon_minigun", 15)
-
+				
 				self.SetDifficulty(1)
 
 				break
 			}
-
+			
 			case "sniper_bow_stun":
 			{
 				self.SetPlayerClass(2)
 				NetProps.SetPropInt(self, "m_Shared.m_iDesiredPlayerClass", 2)
 				self.Regenerate(true)
-
+				
 				self.GetWeapon("tf_weapon_compound_bow", 56)
 				SetFakeClientConVarValue(self, "name", "Ballman")
-
+				
 				self.SetDifficulty(2)
 
 				self.AddBotTag("ballman")
@@ -1441,7 +1468,7 @@
 				break
 			}
 		}
-
+		
 		local tf_class = class_integers[self.GetPlayerClass()]
 
 		if (!self.IsMiniBoss()) self.SetCustomModelWithClassAnimations(format("models/bots/%s/bot_%s.mdl", tf_class, tf_class))
@@ -1449,22 +1476,22 @@
 		{
 			self.SetCustomModelWithClassAnimations(format("models/bots/%s_boss/bot_%s_boss.mdl", tf_class, tf_class))
 			self.SetScaleOverride(1.75)
-
+			
 			for (local i = 1; i <= Constants.Server.MAX_PLAYERS; i++)
 			{
 				local player = PlayerInstanceFromIndex(i)
-
+				
 				if (player == null) continue
 				if (player.IsFakeClient()) continue
 				if (NetProps.GetPropInt(player, "m_lifeState") != 0) continue
-
+				
 				player.AcceptInput("SpeakResponseConcept", "TLK_MVM_GIANT_CALLOUT", null, null)
 			}
 		}
-
+		
 		NetProps.SetPropString(self, "m_PlayerClass.m_iszClassIcon", iconname)
 	}
-
+	
 	ToggleCoffins = function()
 	{
 		switch (coffins_active)
@@ -1473,22 +1500,22 @@
 			{
 				coffins_active = true
 
-				UnhideIcon("dead_blu_lite", 2)
-
+				AddIcon("dead_blu_lite", 2, 0)
+				
 				EmitGlobalSound("Halloween.TeleportVortex.EyeballMovedVortex")
 
 				coffintime_cc.Enable()
-
+				
 				for (local i = 1; i <= Constants.Server.MAX_PLAYERS; i++)
 				{
 					local player = PlayerInstanceFromIndex(i)
 					if (player == null) continue
 					if (IsPlayerABot(player)) continue
-
+					
 					player.ValidateScriptScope()
 					local scope = player.GetScriptScope()
-
-					if (!("saw_teleport_overlay" in scope))
+					
+					if (!("saw_teleport_overlay" in scope)) 
 					{
 						coffinoverlaytime = Time() + 8.0
 						scope.saw_teleport_overlay <- true
@@ -1496,42 +1523,42 @@
 						EntFireByHandle(player, "SetScriptOverlayMaterial", "", 8.0, null, null);
 					}
 				}
-
+				
 				break
 			}
-
+			
 			case true:
 			{
 				coffins_active = false
-
+				
 				HideIcon("dead_blu_lite")
-
+				
 				EmitGlobalSound("ui/halloween_loot_found.wav")
-
+				
 				for (local ent; ent = Entities.FindByName(ent, "spawnbot_coffin*"); ) ent.Disable()
-
+				
 				coffintime_cc.Disable()
-
+				
 				break
 			}
 		}
-
+		
 		for (local ent; ent = Entities.FindByName(ent, "coffin_prop"); ) EntFireByHandle(ent, "RunScriptCode", "self.ResetSequence(self.LookupSequence(self.GetScriptScope().active_anim))", 0.1, null, null)
 	}
-
+	
 	CreateFirePit = function(where, creator, crits)
 	{
 		PrecacheEntityFromTable({ classname = "info_particle_system", effect_name = "cauldron_flamethrower" })
-
+	
 		local tracetable =
 		{
 			start = where
 			end = where - Vector(0, 0, 50)
 			mask = -1
 		}
-
+		
 		TraceLineEx(tracetable)
-
+		
 		if (tracetable.hit)
 		{
 			local firepit = SpawnEntityFromTable("info_particle_system",
@@ -1541,20 +1568,20 @@
 				start_active       = 1,
 				effect_name        = "cauldron_flamethrower"
 			})
-
+			
 			firepit.KeyValueFromString("classname", "firedeath")
-
+			
 			firepit.ValidateScriptScope()
 			firepit.GetScriptScope().owner <- creator
 			firepit.GetScriptScope().team <- creator.GetTeam()
 			firepit.GetScriptScope().crit <- crits
-
+			
 			AddThinkToEnt(firepit, "FirePit_Think")
-
+			
 			EntFireByHandle(firepit, "Kill", null, 3.0, null, null)
-
+			
 			if (!creator.IsFakeClient()) return
-
+			
 			foreach (player in GetAllPlayers(2))
 			{
 				if (TraceLine(where, player.EyePosition(), player) == 1.0)
@@ -1562,7 +1589,7 @@
 					if (!("vistip_firepit" in player.GetScriptScope()))
 					{
 						player.GetScriptScope().vistip_firepit <- true
-						SendGlobalGameEvent("show_annotation",
+						SendGlobalGameEvent("show_annotation", 
 						{
 							id = player.entindex()
 							text = "Pyroman's grenades leave columns\nof fire where they land!"
@@ -1580,12 +1607,12 @@
 			}
 		}
 	}
-
+	
 	HatchSnatcherIntroCutscene = function()
 	{
 		PrecacheSound("ui/cyoa_musicintruderalert.mp3")
 		PrecacheSound("player/taunt_jackhammer_loop.wav")
-
+		
 		foreach (player in GetAllPlayers(2))
 		{
 			local playercam = SpawnEntityFromTable("point_viewcontrol",
@@ -1599,27 +1626,27 @@
 			EntFireByHandle(playercam, "Enable", null, 1.0, player, player)
 
 			EntFireByHandle(playercam, "RunScriptCode", "AddThinkToEnt(self, `CameraRumble_Think`)", 2.5, null, null)
-
+			
 			player.SetMoveType(0, 0)
 			player.AddHudHideFlags(4)
-
+			
 			player.AddCustomAttribute("no_attack", 1, -1)
 			player.AddCustomAttribute("voice pitch scale", 0, -1)
-
+			
 			ScreenFade(player, 0, 0, 0, 255, 1.0, -1.0, 2)
-
+			
 			EntFireByHandle(player, "RunScriptCode", "ScreenFade(self, 0, 0, 0, 255, 1.0, -1.0, 1)", 1.0, null, null)
 
 			EntFireByHandle(player, "RunScriptCode", "ScreenFade(self, 0, 0, 0, 255, 1.0, -1.0, 2)", 9.0, null, null)
 			EntFireByHandle(player, "RunScriptCode", "ScreenFade(self, 0, 0, 0, 255, 1.0, -1.0, 1)", 10.0, null, null)
-
+		
 			EntFireByHandle(player, "RunScriptCode", "self.RemoveHudHideFlags(4)", 10.0, null, null)
-
+			
 			EntFireByHandle(player, "RunScriptCode", "self.SetMoveType(2, 0)", 10.0, null, null)
-
+			
 			EntFireByHandle(player, "RunScriptCode", "self.RemoveCustomAttribute(`no_attack`)", 10.0, null, null)
 			EntFireByHandle(player, "RunScriptCode", "self.RemoveCustomAttribute(`voice pitch scale`)", 10.0, null, null)
-
+			
 			EntFireByHandle(playercam, "Disable", null, 10.0, player, player)
 		}
 
@@ -1628,7 +1655,7 @@
 		EntFireByHandle(gamerules_entity, "RunScriptCode", "EmitGlobalSound(`ui/cyoa_musicintruderalert.mp3`)", 1.0, null, null)
 		EntFireByHandle(gamerules_entity, "RunScriptCode", "EmitGlobalSound(`ui/cyoa_musicintruderalert.mp3`)", 1.0, null, null)
 		EntFireByHandle(gamerules_entity, "RunScriptCode", "EmitGlobalSound(`ui/cyoa_musicintruderalert.mp3`)", 1.0, null, null)
-
+		
 		EntFireByHandle(gamerules_entity, "RunScriptCode", "EmitSoundEx({sound_name = `player/taunt_jackhammer_loop.wav`, channel = 6, filter_type = 5})", 2.5, null, null)
 		EntFireByHandle(gamerules_entity, "RunScriptCode", "hatchsnatcher_cutsceneover = true", 10.0, null, null)
 
@@ -1643,7 +1670,7 @@
 			defaultanim    		 = "taunt01"
 			disablebonefollowers = 1
 		})
-
+		
 		SpawnEntityFromTable("prop_dynamic_ornament",
 		{
 			model                   = "models/player/items/all_class/trn_wiz_hat_pyro.mdl"
@@ -1656,26 +1683,26 @@
 
 		AddThinkToEnt(hatchsnatcher_dummy, "HatchSnatcherDummy_Think")
 	}
-
+	
 	CameraRumble_Think = function()
 	{
 		if (endshaking) return
-
+		
 		local choice = RandomInt(0, 1)
-
+		
 		if (choice == 0) self.SetAbsAngles(self.GetAbsAngles() + QAngle(RandomInt(0, 1) == 0 ? 0.33 : -0.33, 0, 0))
 		if (choice == 1) self.SetAbsAngles(self.GetAbsAngles() + QAngle(0, RandomInt(0, 1) == 0 ? 0.33 : -0.33, 0))
 
 		return -1
 	}
-
+	
 	Coffin_Think = function()
 	{
 		if (thinkertick % 7 != 0) return
 		if (!intel_entity.IsValid()) return
-
+		
 		local intel_y = intel_entity.GetOrigin().y
-
+		
 		if (!coffins_active) return
 
 		for (local ent; ent = Entities.FindByName(ent, "spawnbot_coffin_front"); )
@@ -1684,14 +1711,14 @@
 			if (intel_y >= -1000.0 && intel_y < 1500.0) ent.Disable()
 			if (intel_y >= 1500.0)						ent.Enable()
 		}
-
+		
 		for (local ent; ent = Entities.FindByName(ent, "spawnbot_coffin_middle"); )
 		{
 			if (intel_y < -1000.0) 						ent.Enable()
 			if (intel_y >= -1000.0 && intel_y < 1500.0) ent.Disable()
 			if (intel_y >= 1500.0)						ent.Disable()
 		}
-
+		
 		for (local ent; ent = Entities.FindByName(ent, "spawnbot_coffin_back"); )
 		{
 			if (intel_y < -1000.0) 						ent.Enable()
@@ -1699,19 +1726,19 @@
 			if (intel_y >= 1500.0)						ent.Disable()
 		}
 	}
-
+	
 	CoffinProp_Think = function()
 	{
 		local scope = self.GetScriptScope()
-
+		
 		if (!("beam" in scope))
 		{
 			scope.active_anim <- null
-
+			
 			local unique = UniqueString()
-
+			
 			scope.beam_apex <- SpawnEntityFromTable("info_teleport_destination", { targetname = unique, origin = self.GetOrigin() + Vector(0, 0, 1500) })
-
+			
 			scope.beam <- SpawnEntityFromTable("env_beam",
 			{
 				targetname				= self.GetName() + "_beam_" + unique
@@ -1726,7 +1753,7 @@
 				spawnflags				= 0
 			})
 		}
-
+		
 		if (!NetProps.GetPropBool(associated_spawn_ent, "m_bDisabled"))
 		{
 			scope.active_anim = "taunt_the_crypt_creeper_A1"
@@ -1736,11 +1763,11 @@
 		{
 			scope.active_anim = "ref"
 			if (NetProps.GetPropInt(scope.beam, "m_active") == 1) scope.beam.AcceptInput("TurnOff", null, null, null)
-		}
+		}			
 
 		self.StudioFrameAdvance()
 		self.DispatchAnimEvents(self)
-
+		
 		if (self.GetSequenceName(self.GetSequence()).find("A1") != null)
 		{
 			if (self.GetCycle() > 0.7) self.ResetSequence(self.LookupSequence(scope.active_anim))
@@ -1755,17 +1782,17 @@
 
 		return -1
 	}
-
+	
 	Conch_Think = function()
 	{
 		foreach (player in GetAllPlayers(3, [self.GetOrigin(), 450.0]))
 		{
 			player.AddCondEx(29, 0.25, self)
-
+			
 			local foundaura = false
 
 			for (local child = player.FirstMoveChild(); child != null; child = child.NextMovePeer()) { if (child.GetName() == "conchbuffaura") foundaura = true }
-
+			
 			if (foundaura) continue
 
 			local buffaura = SpawnEntityFromTable("info_particle_system",
@@ -1778,18 +1805,18 @@
 			})
 
 			buffaura.AcceptInput("SetParent", "!activator", player, player)
-
+			
 			EntFireByHandle(buffaura, "Kill", null, 1.0, null, null)
 		}
 
 		return 0.1
 	}
-
+	
 	Ballman_Think = function()
 	{
 		try { self.GetScriptScope() }
 		catch (e) { return -1 }
-
+		
 		local owner = NetProps.GetPropEntity(self, "m_hOwner")
 		local scope = self.GetScriptScope()
 
@@ -1819,12 +1846,12 @@
 		}
 
 		else chargetime = 0.0
-
+		
 		for (local ent; ent = Entities.FindByClassname(ent, "tf_projectile_arrow"); )
 		{
 			if (ent.GetOwner() != owner) continue
 
-			local ball = SpawnEntityFromTable("tf_projectile_stun_ball",
+			local ball = SpawnEntityFromTable("tf_projectile_stun_ball", 
 			{
 				teamnum      = ent.GetTeam()
 				origin       = ent.GetOrigin()
@@ -1833,7 +1860,7 @@
 
 			ball.SetMoveType(5, 2)
 			ball.SetGravity(ballgravity)
-
+			
 			local vecVelocity = Vector(0, 0, 0)
 			vecVelocity += owner.EyeAngles().Forward() * 15
 			vecVelocity += owner.EyeAngles().Up() * 0.5
@@ -1844,52 +1871,52 @@
 
 			ball.SetOwner(owner)
 			NetProps.SetPropEntity(ball, "m_hLauncher", ball) // this will let us access the ball in ontakedamage hook
-
+			
 			ball.ValidateScriptScope()
 			ball.GetScriptScope().ignite <- false
 			ball.GetScriptScope().weapon <- self
 			ball.GetScriptScope().fullstun <- fullstun
-
+			
 			fullstun = false
-
+			
 			AddThinkToEnt(ball, "Ball_Think")
-
+			
 			if (NetProps.GetPropBool(ent, "m_bArrowAlight"))
 			{
 				ball.GetScriptScope().ignite = true
-
+				
 				local particle = SpawnEntityFromTable("trigger_particle",
 				{
 					particle_name = "m_brazier_flame"
 					attachment_type = 1
 					spawnflags = 64
 				})
-
+				
 				NetProps.SetPropBool(particle, "m_bForcePurgeFixedupStrings", true)
-
+				
 				particle.AcceptInput("StartTouch", "!activator", ball, ball)
 				particle.Kill()
 			}
-
+			
 			if (NetProps.GetPropBool(ent, "m_bCritical")) NetProps.SetPropBool(ball, "m_bCritical", true)
 
 			ent.Kill()
 		}
-
+		
 		return -1
 	}
-
+	
 	FireDemo_Think = function()
 	{
 		local owner = NetProps.GetPropEntity(self, "m_hOwner")
-
+		
 		for (local ent; ent = Entities.FindByClassname(ent, "tf_projectile_pipe"); )
 		{
 			if (NetProps.GetPropEntity(ent, "m_hThrower") != owner) continue
-
+			
 			ent.ValidateScriptScope()
 			local proj_scope = ent.GetScriptScope()
-
+			
 			if (!("flameparticle" in proj_scope))
 			{
 				proj_scope.flameparticle <- SpawnEntityFromTable("trigger_particle",
@@ -1898,49 +1925,49 @@
 					attachment_type = 1
 					spawnflags = 64
 				})
-
+				
 				proj_scope.flameparticle.AcceptInput("StartTouch", "!activator", ent, ent)
 				proj_scope.flameparticle.Kill()
-
+				
 				proj_scope.owner <- owner
 				proj_scope.crit <- (NetProps.GetPropBool(ent, "m_bCritical")) ? 1048576 : 0
-
+		
 				proj_scope.OnGameEvent_object_deflected <- function(params)
 				{
 					if (params.object_entindex == owner.entindex()) owner = GetPlayerFromUserID(params.userid)
 				}
-
+				
 				SetDestroyCallback(ent, function() { CreateFirePit(self.GetOrigin(), self.GetScriptScope().owner, self.GetScriptScope().crit) })
-
+				
 				__CollectGameEventCallbacks(proj_scope)
 			}
 		}
-
+		
 		return -1
 	}
-
+	
 	MedicShotgun_Think = function()
 	{
 		local scope = self.GetScriptScope()
-
+		
 		if (!("patient_alive" in scope))
 		{
 			if (self.HasBotTag("no_patient"))
 			{
 				scope.patient_alive <- false
-
+				
 				if (sigmod) self.AcceptInput("$BotCommand", "switch_action FetchFlag", null, null)
 
 				local origmodel = self.GetModelName()
-
+				
 				self.SetCustomModelWithClassAnimations("models/bots/heavy_boss/bot_heavy_boss.mdl")
 				self.KeyValueFromInt("rendermode", 1)
 				self.KeyValueFromInt("renderamt", 0)
-
+				
 				local newmodel = self.GetWearable(origmodel)
-
+				
 				newmodel.KeyValueFromString("targetname", "glow_target")
-
+				
 				scope.glow <- SpawnEntityFromTable("tf_glow",
 				{
 					target           	  = "glow_target"
@@ -1949,34 +1976,34 @@
 					GlowColor			  = "125 168 196 255"
 					StartDisabled		  = 1
 				})
-
+				
 				scope.glow.AcceptInput("SetParent", "!activator", newmodel, newmodel)
-
+				
 				newmodel.KeyValueFromString("targetname", "")
 
 				local shotgun = self.GetWeapon("tf_weapon_shotgun_hwg", 11)
-
+				
 				shotgun.AddAttribute("fire rate bonus", 2.5, -1.0)
 				shotgun.AddAttribute("bullets per shot bonus", 10.0, -1.0)
 				shotgun.AddAttribute("damage penalty", 0.5, -1.0)
 				shotgun.AddAttribute("faster reload rate", 0.1, -1.0)
 			}
-
+			
 			if (self.GetHealTarget() == null) return -1
-
+			
 			self.AddBotAttribute(8)
 
 			scope.patient_alive <- true
-
+			
 			scope.medigun <- NetProps.GetPropEntityArray(self, "m_hMyWeapons", 1)
 			scope.patient <- self.GetHealTarget()
-
+			
 			scope.connected <- false
 			scope.distlimit <- 450
-
+			
 			// scope.lifetime <- 1.0
 			// scope.drain_amount <- 24.0
-
+			
 			// scope.drain_amount <- format("%.1f", (scope.patient.GetMaxHealth().tofloat() / 1750.0)).tofloat()
 			scope.drain_amount <- 7.0
 			scope.drainbank_amount <- 0
@@ -1984,7 +2011,7 @@
 			scope.drain_interval <- 10
 
 			// local attempts = 1
-
+			
 			// the more you add a number to itself, the less accurate the result! adding 0.7 to itself ten times in this loop below won't return 7!
 			// the only way is to multiply it by a number, reset it if it doesn't match, and then increase the multiplier
 
@@ -2003,13 +2030,13 @@
 			scope.nextdraintime <- thinkertick + scope.drain_interval
 
 			if (scope.patient.GetPlayerClass() == 1) self.AddCustomAttribute("CARD: move speed bonus", 10, -1.0)
-
+			
 			local patient_beamend = UniqueString()
 			local healer_beamstart = UniqueString()
 
 			scope.medigun.KeyValueFromString("targetname", healer_beamstart)
 			scope.patient.KeyValueFromString("targetname", patient_beamend)
-
+			
 			scope.beam_start <- SpawnEntityFromTable("env_beam",
 			{
 				targetname				= healer_beamstart
@@ -2023,26 +2050,26 @@
 				texture					= "sprites/laserbeam.spr"
 				spawnflags				= 0
 			})
-
+			
 			scope.medigun.KeyValueFromString("targetname", "")
 			scope.patient.KeyValueFromString("targetname", "")
-
+			
 			scope.dist <- 0
-
+			
 			shotguncallbacks <-
 			{
 				OnGameEvent_player_death = function(params)
 				{
 					local dead_player = GetPlayerFromUserID(params.userid)
-
+					
 					if (dead_player == self)
 					{
 						self.KeyValueFromInt("rendermode", 0)
-
+						
 						self.SetCustomModelWithClassAnimations("models/bots/medic/bot_medic.mdl")
-
+						
 						intel_entity.AcceptInput("ForceGlowDisabled", "0", null, null)
-
+						
 						delete shotguncallbacks
 
 						return
@@ -2053,19 +2080,19 @@
 						if (dead_player == scope.patient)
 						{
 							if (sigmod) self.AcceptInput("$BotCommand", "switch_action FetchFlag", null, null)
-
+							
 							self.RemoveCustomAttribute("CARD: move speed bonus")
-
+							
 							local origmodel = self.GetModelName()
-
+							
 							self.SetCustomModelWithClassAnimations("models/bots/heavy_boss/bot_heavy_boss.mdl")
 							self.KeyValueFromInt("rendermode", 1)
 							self.KeyValueFromInt("renderamt", 0)
-
+							
 							local newmodel = self.GetWearable(origmodel)
-
+							
 							newmodel.KeyValueFromString("targetname", "glow_target")
-
+							
 							scope.glow <- SpawnEntityFromTable("tf_glow",
 							{
 								target           	  = "glow_target"
@@ -2073,23 +2100,23 @@
 								GlowColor			  = "125 168 196 255"
 								StartDisabled		  = 1
 							})
-
+							
 							scope.glow.AcceptInput("SetParent", "!activator", newmodel, newmodel)
-
+							
 							newmodel.KeyValueFromString("targetname", "")
-
+							
 							try { scope.beam_start.Kill() }
 							catch (e) {}
-
+							
 							local shotgun = self.GetWeapon("tf_weapon_shotgun_hwg", 11)
-
+							
 							shotgun.AddAttribute("fire rate bonus", 2.5, -1.0)
 							shotgun.AddAttribute("bullets per shot bonus", 10.0, -1.0)
 							shotgun.AddAttribute("damage penalty", 0.5, -1.0)
 							shotgun.AddAttribute("faster reload rate", 0.1, -1.0)
-
+							
 							EntFireByHandle(self, "RunScriptCode", "self.RemoveBotAttribute(8)", 2.5, null, null)
-
+							
 							self.EmitSound("vo/mvm/norm/medic_mvm_" + medicshotgun_soundarray[RandomInt(0, medicshotgun_soundarray.len() - 1)] + ".mp3")
 
 							scope.patient_alive = false
@@ -2097,7 +2124,7 @@
 					}
 				}
 			}
-
+			
 			foreach (name, callback in shotguncallbacks) shotguncallbacks[name] = callback.bindenv(scope)
 
 			__CollectGameEventCallbacks(shotguncallbacks)
@@ -2114,10 +2141,10 @@
 						if (!("vistip_medicshotgun" in player.GetScriptScope()))
 						{
 							player.GetScriptScope().vistip_medicshotgun <- true
-							SendGlobalGameEvent("show_annotation",
+							SendGlobalGameEvent("show_annotation", 
 							{
 								id = player.entindex()
-								text = "Giant Shotgun Medics steal\nhealth from their patients!"
+								text = "Giant Shotgun Medics leech\nhealth from their patients!"
 								follow_entindex = self.entindex()
 								visibilityBitfield = (1 << player.entindex())
 								play_sound = "misc/null.wav"
@@ -2128,62 +2155,62 @@
 						}
 					}
 				}
-
+				
 				if (!scope.connected)
 				{
 					scope.distlimit = 450
 					scope.patient.AddCustomAttribute("CARD: move speed bonus", 0.01, -1.0)
 				}
-
+				
 				else
 				{
 					scope.patient.RemoveCustomAttribute("CARD: move speed bonus")
 					scope.distlimit = 540
 				}
-
+				
 				// scope.lifetime += 0.015
-
+				
 				// local drain_rate = (self.GetMaxHealth().tofloat() / self.GetHealth().tofloat()) * scope.lifetime
 
 				// scope.drain_amount = 24.0 * drain_rate
-
+				
 				// if (scope.drain_amount > 432.0) scope.drain_amount = 432.0
-
+				
 				// NetProps.SetPropFloat(scope.beam_start, "m_boltWidth", (drain_rate < 6.0) ? drain_rate * 4.0 : 25.0)
-
+				
 				scope.dist = (scope.patient.GetCenter() - scope.medigun.GetOrigin()).Length()
-
+				
 				if (scope.dist > scope.distlimit) { { if (NetProps.GetPropInt(scope.beam_start, "m_active") == 1) scope.beam_start.AcceptInput("TurnOff", null, null, null) } ; scope.connected = false }
 				else							  { { if (NetProps.GetPropInt(scope.beam_start, "m_active") == 0) scope.beam_start.AcceptInput("TurnOn", null, null, null) } ; scope.connected = true }
 			}
-
+			
 			if (scope.connected && scope.nextdraintime <= thinkertick)
 			{
 				// local drainperframe = scope.drain_amount
 				// local origdrainperframe = drainperframe
-
+				
 				// local interval = 1
-
+				
 				// for (local i = drainperframe; i < 1.0; i *= 2.0)
 				// for (local i = drainperframe; i < 1.0; i *= 2.0)
 				// {
 					// drainperframe += origdrainperframe
 					// interval++
 				// }
-
+				
 				scope.nextdraintime = thinkertick + scope.drain_interval
-
+				
 				if (scope.patient.GetHealth().tofloat() < 35.0) scope.patient.TakeDamage(195.0, 64, scope.patient)
-
+				
 				// else scope.patient.SetHealth(scope.patient.GetHealth().tofloat() - drainperframe)
 				else scope.patient.SetHealth(scope.patient.GetHealth().tofloat() - scope.drain_amount)
-
+				
 				// if (self.GetHealth() < self.GetMaxHealth()) self.SetHealth(self.GetHealth().tofloat() + drainperframe)
 				if (self.GetHealth() < self.GetMaxHealth())
 				{
 					// self.SetHealth(self.GetHealth().tofloat() + drainperframe)
 					self.SetHealth(self.GetHealth().tofloat() + scope.drain_amount)
-
+					
 					if (scope.drainbank_amount > 0)
 					{
 						// self.SetHealth(self.GetHealth().tofloat() + drainperframe)
@@ -2192,12 +2219,12 @@
 						scope.drainbank_amount -= scope.drain_amount
 					}
 				}
-
+				
 				// else scope.drainbank_amount += drainperframe
 				else scope.drainbank_amount += scope.drain_amount
 			}
 		}
-
+		
 		else
 		{
 			foreach (player in GetAllPlayers(2))
@@ -2207,7 +2234,7 @@
 					if (TraceLine(self.EyePosition(), player.EyePosition(), self) == 1.0)
 					{
 						player.GetScriptScope().vistip_medicshotgun2 <- true
-						SendGlobalGameEvent("show_annotation",
+						SendGlobalGameEvent("show_annotation", 
 						{
 							id = player.entindex()
 							text = "When their patient dies,\nthey bring out their shotguns!"
@@ -2221,7 +2248,7 @@
 					}
 				}
 			}
-
+			
 			if (self.HasItem())
 			{
 				intel_entity.AcceptInput("ForceGlowDisabled", "1", null, null)
@@ -2231,11 +2258,11 @@
 
 		return -1
 	}
-
+	
 	SamuraiSoldier_Think = function()
 	{
 		local scope = self.GetScriptScope()
-
+		
 		if (!("jumping" in scope))
 		{
 			scope.origmodel <- self.GetModelName()
@@ -2246,12 +2273,12 @@
 			scope.activated <- false
 			// scope.leader <- null
 			scope.hat <- (!self.HasBotTag("samurai_minion")) ? "models/player/items/soldier/soldier_samurai.mdl" : "models/workshop/player/items/sniper/robo_sniper_soldered_sensei/robo_sniper_soldered_sensei.mdl"
-
+			
 			if (self.HasBotTag("samurai_minion"))
 			{
 				local hat = self.GetWearable(hat, false, "head", [Vector(5, 0, -128), QAngle()])
 				hat.SetModelScale(1.45, -1.0)
-
+				
 				foreach (player in GetAllPlayers(3))
 				{
 					if (player.HasBotTag("valid_samurai"))
@@ -2262,28 +2289,26 @@
 				}
 			}
 		}
-
+		
 		if (dummymodel != null)
 		{
 			if (dummymodel.GetCycle() >= 0.8)
 			{
 				local dummykill = dummymodel
-
+				
 				dummymodel = null
 				dummykill.Kill()
-
+				
 				self.SetMoveType(2, 0)
-
-				for (local ent; ent = Entities.FindByName(ent, "samurai_soldier_sfx"); ) ent.Kill()
-
+				
 				self.SetCustomModelOffset(Vector())
 			}
 		}
-
+		
 		if (thinkertick % 6 != 0) return -1
-
+		
 		if (jumping && self.IsGrounded()) jumping = false
-
+		
 		if (jumping && self.GetAbsVelocity().z <= 0 && !in_cooldown)
 		{
 			foreach (player in GetAllPlayers(2))
@@ -2293,7 +2318,7 @@
 					if (!("vistip_samuraisoldier" in player.GetScriptScope()))
 					{
 						player.GetScriptScope().vistip_samuraisoldier <- true
-						SendGlobalGameEvent("show_annotation",
+						SendGlobalGameEvent("show_annotation", 
 						{
 							id = player.entindex()
 							text = "Samurai Soldiers duplicate\nthemselves when they jump!"
@@ -2310,11 +2335,11 @@
 					}
 				}
 			}
-
+			
 			self.SetMoveType(0, 0)
 
 			self.SetCustomModelOffset(Vector(0, 0, -5000))
-
+			
 			dummymodel = SpawnEntityFromTable("prop_dynamic",
 			{
 				targetname			 = "dummymodel_" + self.entindex()
@@ -2327,7 +2352,7 @@
 				rendermode			 = 1
 				renderamt			 = 0
 			})
-
+			
 			SpawnEntityFromTable("prop_dynamic_ornament",
 			{
 				model                   = origmodel
@@ -2336,7 +2361,7 @@
 				disablebonefollowers	= 1
 				initialowner			= "dummymodel_" + self.entindex()
 			})
-
+			
 			SpawnEntityFromTable("prop_dynamic_ornament",
 			{
 				model                   = hat
@@ -2345,13 +2370,13 @@
 				disablebonefollowers	= 1
 				initialowner			= "dummymodel_" + self.entindex()
 			})
-
+			
 			if (!self.HasBotTag("samurai_minion"))
 			{
 				EnableSpawn("samurai")
 				EntFireByHandle(samurai_spawn, "Disable", null, 0.1, null, null)
 			}
-
+			
 			else
 			{
 				EnableSpawn("samurai_2")
@@ -2360,13 +2385,13 @@
 
 			self.AddBotTag("valid_samurai")
 			EntFireByHandle(self, "RunScriptCode", "self.RemoveBotTag(`valid_samurai`)", 0.1, null, null)
-
+			
 			PrecacheSound("items/samurai/TF_samurai_noisemaker_setA_01.wav")
 			PrecacheSound("items/samurai/TF_samurai_noisemaker_setA_02.wav")
 			PrecacheSound("items/samurai/TF_samurai_noisemaker_setA_03.wav")
 			PrecacheSound("items/samurai/TF_conch.wav")
 			PrecacheSound("sfx_supermove.wav")
-
+			
 			if (!activated)
 			{
 				if (thinkertick >= nextconchsoundtime)
@@ -2375,34 +2400,33 @@
 					nextconchsoundtime = thinkertick + 66
 				}
 			}
-
+			
 			EmitSoundEx({sound_name = "items/samurai/TF_samurai_noisemaker_setA_0" + RandomInt(1, 3) + ".wav", channel = 6, entity = self, sound_level = 150})
 			EmitSoundEx({sound_name = "sfx_supermove.wav", channel = 6, entity = self, sound_level = 150})
-
-			SpawnEntityFromTable("info_particle_system", { targetname = "samurai_soldier_sfx", origin = self.EyePosition() + Vector(RandomInt(-150, 150), RandomInt(-150, 150), RandomInt(-150, 150)), effect_name = "eyeboss_team_blue", start_active = 1, flag_as_weather = 0 } )
-			SpawnEntityFromTable("info_particle_system", { targetname = "samurai_soldier_sfx", origin = self.EyePosition() + Vector(RandomInt(-150, 150), RandomInt(-150, 150), RandomInt(-150, 150)), effect_name = "eyeboss_team_blue", start_active = 1, flag_as_weather = 0 } )
-			SpawnEntityFromTable("info_particle_system", { targetname = "samurai_soldier_sfx", origin = self.EyePosition() + Vector(RandomInt(-150, 150), RandomInt(-150, 150), RandomInt(-150, 150)), effect_name = "eyeboss_team_blue", start_active = 1, flag_as_weather = 0 } )
-			SpawnEntityFromTable("info_particle_system", { targetname = "samurai_soldier_sfx", origin = self.EyePosition() + Vector(RandomInt(-150, 150), RandomInt(-150, 150), RandomInt(-150, 150)), effect_name = "eyeboss_team_blue", start_active = 1, flag_as_weather = 0 } )
-			SpawnEntityFromTable("info_particle_system", { targetname = "samurai_soldier_sfx", origin = self.EyePosition() + Vector(RandomInt(-150, 150), RandomInt(-150, 150), RandomInt(-150, 150)), effect_name = "eyeboss_team_blue", start_active = 1, flag_as_weather = 0 } )
-			SpawnEntityFromTable("info_particle_system", { targetname = "samurai_soldier_sfx", origin = self.EyePosition() + Vector(RandomInt(-150, 150), RandomInt(-150, 150), RandomInt(-150, 150)), effect_name = "eyeboss_team_blue", start_active = 1, flag_as_weather = 0 } )
+			
+			for (local i = 0; i <= 5; i++)
+			{
+				local sfx = SpawnEntityFromTable("info_particle_system", { origin = self.EyePosition() + Vector(RandomInt(-150, 150), RandomInt(-150, 150), RandomInt(-150, 150)), effect_name = "eyeboss_team_blue", start_active = 1, flag_as_weather = 0 } )
+				EntFireByHandle(sfx, "Kill", null, 3.0, null, null)
+			}
 
 			activated = true
 			in_cooldown = true
-
+			
 			cooldown_exittime = thinkertick + (1000 * RandomFloat(0.75, 1.25))
 		}
-
+		
 		if (self.IsGrounded() && !in_cooldown)
 		{
 			local alivesamurais = 0
-
+			
 			foreach (player in GetAllPlayers(3))
 			{
 				if (!player.HasBotTag("samurai_soldier")) continue
-
+				
 				alivesamurais++
 			}
-
+			
 			if (alivesamurais < 10)
 			{
 				local trace =
@@ -2414,9 +2438,9 @@
 					mask = 33636363,
 					ignore = self
 				}
-
+				
 				TraceHull(trace)
-
+				
 				if (!("startsolid" in trace))
 				{
 					self.GetLocomotionInterface().Jump()
@@ -2424,15 +2448,15 @@
 				}
 			}
 		}
-
+		
 		if (in_cooldown && (thinkertick >= cooldown_exittime)) in_cooldown = false
-
+		
 		if (activated)
 		{
 			foreach (player in GetAllPlayers(3, [self.GetOrigin(), 450.0]))
 			{
 				player.AddCondEx(29, 0.25, self)
-
+				
 				local foundaura = false
 
 				for (local child = player.FirstMoveChild(); child != null; child = child.NextMovePeer()) { if (child.GetName() == "conchbuffaura") foundaura = true }
@@ -2447,12 +2471,12 @@
 				})
 
 				buffaura.AcceptInput("SetParent", "!activator", player, player)
-
+				
 				EntFireByHandle(buffaura, "Kill", null, 1.0, null, null)
 			}
 		}
 	}
-
+	
 	FirePit_Think = function()
 	{
 		for (local entity_to_burn; entity_to_burn = Entities.FindInSphere(entity_to_burn, self.GetOrigin(), 90.0); )
@@ -2461,12 +2485,12 @@
 			if (entity_to_burn.GetClassname() == "tf_projectile_arrow") NetProps.SetPropBool(entity_to_burn, "m_bArrowAlight", true)
 
 			if (entity_to_burn.GetTeam() == team) continue
-
+			
 			local dmg = (entity_to_burn.GetClassname() == "obj_sentrygun") ? 3.25 : 6.5
 
 			entity_to_burn.TakeDamageEx(self, owner, ignite_player, Vector(0, 0, 0), entity_to_burn.GetOrigin(), dmg, 8 + crit)
 		}
-
+		
 		return 0.075
 	}
 
@@ -2481,24 +2505,24 @@
 		{
 			if (NetProps.GetPropFloat(gamerules_entity, "m_flRestartRoundTime") > Time() + 5.1 && NetProps.GetPropFloat(gamerules_entity, "m_flRestartRoundTime") < Time() + 10.1) NetProps.SetPropFloat(gamerules_entity, "m_flRestartRoundTime", Time() + 5.0)
 		}
-
+		
 		if (thinkertick % 6 != 0) return
-
+		
 		NavMesh.GetNavAreaByID(126).SetAttributeTF(4) // those occassionally have their flags reset
 		NavMesh.GetNavAreaByID(155).SetAttributeTF(4)
 		NavMesh.GetNavAreaByID(1997).SetAttributeTF(4)
-
+		
 		foreach (player in GetAllPlayers(3))
 		{
 			local bounds = (player.HasBotAttribute(32768)) ? Vector(154, 66, 136) : Vector(128, 44, 136)
-
+			
 			if (IsInside(player.GetOrigin(), Vector(1016, -2336, -16) - bounds, Vector(1016, -2336, -16) + bounds))
 			{
-				player.Teleport(true, player.GetOrigin() + Vector(0, 64, 8), false, QAngle(), false, Vector())
+				player.Teleport(true, player.GetOrigin() + Vector(0, 72, 8), false, QAngle(), false, Vector())
 			}
 		}
 	}
-
+	
 	SuppressWaveEndMusic_Think = function()
 	{
 		if (suppress_waveend_music)
@@ -2509,13 +2533,13 @@
 			StopGlobalSound("music.mvm_end_tank_wave")
 		}
 	}
-
+	
 	DuckySpawn_Think = function()
 	{
 		if (thinkertick < duckyspawn_time) return
-
+		
 		local choice = duckyspawn_locations[RandomInt(0, duckyspawn_locations.len() - 1)]
-
+		
 		local ducky = SpawnEntityFromTable("prop_dynamic",
 		{
 			model	   = "models/items/target_duck.mdl"
@@ -2523,36 +2547,36 @@
 		})
 
 		AddThinkToEnt(ducky, "DuckyPickup_Think")
-
+		
 		duckyspawn_locations.remove(duckyspawn_locations.find(choice))
-
+		
 		duckyspawn_amount++
-
+		
 		if (duckyspawn_amount >= 3) RemoveThinkFromThinksTable("DuckySpawn_Think")
-
+		
 		duckyspawn_time = thinkertick + 4000
 	}
-
+	
 	DuckyPickup_Think = function()
 	{
 		self.SetAbsAngles(self.GetAngles() + QAngle(0, 1, 0))
-
+		
 		foreach (player in GetAllPlayers(2, [self.GetOrigin(), 72.0]))
 		{
 			if (player.IsFakeClient()) continue
-
+			
 			local scope = player.GetScriptScope()
-
+			
 			if (!("hasducky" in scope))
 			{
 				scope.hasducky <- true
-
+				
 				EmitSoundEx({ sound_name = "Halloween.Quack", filter_type = 4, flags = 0, entity = player, channel = 6 })
-
+				
 				DispatchParticleEffect("halloween_explosion", self.GetOrigin(), Vector(0, 90, 0))
-
+				
 				duckyspawn_pickups++
-
+				
 				if (duckyspawn_pickups >= 3)
 				{
 					secretwave_unlocked = true
@@ -2561,23 +2585,23 @@
 
 					NetProps.SetPropInt(objective_resource_entity, "m_nMannVsMachineMaxWaveCount", 6)
 				}
-
+				
 				NetProps.SetPropString(self, "m_iszScriptThinkFunction", "")
 				AddThinkToEnt(self, null)
 				self.Kill()
 				return 1
 			}
-
+			
 			else ClientPrint(player, 4, "Someone else has to pick this up")
 		}
-
+		
 		return -1
 	}
-
+	
 	HatchSnatcherDummy_Think = function()
 	{
 		local scope = self.GetScriptScope()
-
+		
 		if (!("hatch" in scope))
 		{
 			scope.orighatch <- Entities.FindByName(null, "hatch")
@@ -2587,28 +2611,28 @@
 				model                = "models/props_mvm/mann_hatch.mdl"
 				disablebonefollowers = 1
 			})
-
+			
 			scope.finished1 <- false
 			scope.finished2 <- false
-
+			
 			hatch.AcceptInput("SetParent", "!activator", self, self)
-
+			
 			EntFireByHandle(hatch, "SetParentAttachment", "weapon_bone", 0.1, null, null) // 20 57 out of 67
-
+			
 			EntFireByHandle(hatch, "RunScriptCode", "self.SetLocalOrigin(Vector(0, 0, 30))", 0.5, null, null)
 			EntFireByHandle(hatch, "RunScriptCode", "self.SetLocalAngles(QAngle(0, -20, 85))", 0.5, null, null)
-
+			
 			PrecacheSound("player/taunt_jackhammer_down_strike.wav")
 			PrecacheSound("player/taunt_jackhammer_loop.wav")
 			PrecacheSound("player/taunt_jackhammer_loop_end.wav")
 
 			PrecacheEntityFromTable({ classname = "info_particle_system", effect_name = "hammer_impact_button_dust2" })
 		}
-
+		
 		if (self.GetCycle() < 0.3 || self.GetCycle() > 0.75) self.SetCycle(0.3)
-
+		
 		if (self.GetOrigin().z > -365 && self.GetOrigin().z < -325) DispatchParticleEffect("hammer_impact_button_dust2", self.EyePosition() + Vector(0, 0, 200), Vector(0, 90, 0))
-
+		
 		if (self.GetOrigin().z > -365)
 		{
 			if (!finished1)
@@ -2619,9 +2643,9 @@
 				EmitSoundEx({sound_name = "player/taunt_jackhammer_down_strike.wav", channel = 6, filter_type = 5})
 			}
 		}
-
+		
 		if (self.GetOrigin().z < -206) self.SetOrigin(self.GetOrigin() + Vector(0, 0, 0.5))
-
+		
 		else if (!finished2)
 		{
 			finished2 = true
@@ -2630,19 +2654,19 @@
 			EmitSoundEx({sound_name = "player/taunt_jackhammer_loop_end.wav", channel = 6, filter_type = 5})
 			EmitGlobalSound("vo/taunts/pyro/pyro_taunt_flip_exert_06.mp3")
 		}
-
+		
 		self.StudioFrameAdvance()
 		self.DispatchAnimEvents(self)
-
+		
 		if (hatchsnatcher_cutsceneover) self.Kill()
-
+		
 		return -1
 	}
-
+	
 	HatchSnatcher_Think = function()
 	{
 		local scope = self.GetScriptScope()
-
+		
 		if (!("hatchprop" in scope))
 		{
 			scope.holeblock_deco <- SpawnEntityFromTable("prop_dynamic",
@@ -2663,7 +2687,7 @@
 			holeblock_brush.KeyValueFromInt("solid", 2)
 			holeblock_brush.KeyValueFromString("mins", "-1 -300 -200")
 			holeblock_brush.KeyValueFromString("maxs", "1 0 500")
-
+			
 			scope.aggrodestinations <-
 			[
 				Vector(900, -1800, 0), // initial
@@ -2680,10 +2704,10 @@
 				Vector(1150, 3950, 100), // back
 				Vector(-300, 3500, 100) // back
 			]
-
+			
 			scope.voicecooldown <- thinkertick + RandomInt(350, 650)
 			scope.tauntcooldown <- thinkertick + RandomInt(2000, 3000)
-
+			
 			scope.aggrotarget <- SpawnEntityFromTable("prop_dynamic",
 			{
 				targetname    = "aggrotarget"
@@ -2693,13 +2717,13 @@
 				rendermode	  = 1
 				renderamt 	  = 0
 			})
-
+			
 			SpawnEntityFromTable("filter_tf_bot_has_tag",
 			{
 				targetname 		 = "filter_hatchsnatcher"
 				tags       		 = "hatch_snatcher"
 			})
-
+			
 			local snatcher_logic = SpawnEntityFromTable("func_nav_prerequisite",
 			{
 				filtername = "filter_hatchsnatcher"
@@ -2707,45 +2731,46 @@
 				Entity	   = "aggrotarget"
 				spawnflags = 3
 			})
-
+			
 			snatcher_logic.KeyValueFromInt("solid", 2)
 			snatcher_logic.KeyValueFromString("mins", "-9999 -9999 -9999")
 			snatcher_logic.KeyValueFromString("maxs", "9999 9999 9999")
-
+			
 			RegisterScriptGameEventListener("round_start")
 			SendGlobalGameEvent("round_start", {})
-
+			
 			scope.origmodel <- self.GetModelName()
-
+			
 			self.SetCustomModelWithClassAnimations("models/player/soldier.mdl")
 			self.KeyValueFromInt("rendermode", 1)
 			self.KeyValueFromInt("renderamt", 0)
-
+			
 			local fakemodel = self.GetWearable(origmodel)
-			self.GetWearable("models/player/items/all_class/trn_wiz_hat_soldier.mdl")
-
+			// self.GetWearable("models/player/items/all_class/trn_wiz_hat_soldier.mdl")
+			self.GetWearableItem(634)
+			
 			fakemodel.KeyValueFromString("targetname", "glow_target")
-
+			
 			scope.glow <- SpawnEntityFromTable("tf_glow",
 			{
 				target           	  = "glow_target"
 				// GlowColor             = "153 220 255 255"
 				GlowColor			  = "125 168 196 255"
 			})
-
+			
 			glow.AcceptInput("SetParent", "!activator", fakemodel, fakemodel)
-
+			
 			fakemodel.KeyValueFromString("targetname", "")
-
+			
 			scope.hatchprop <- self.GetWearable("models/props_mvm/mann_hatch.mdl", false, "head", [Vector(50, 10, 0), QAngle(40, 0, 0)])
-
+			
 			hatchprop.SetModelScale(0.75, -1.0)
-
+			
 			scope.tauntmodel <- null
-
+			
 			self.Teleport(true, Vector(642.364, 3544.41, -206), false, QAngle(), false, Vector())
 			self.StunPlayer(3600.0, 0.0, 64, self)
-
+			
 			foreach (player in GetAllPlayers(2))
 			{
 				local dir = RandomInt(0, 1)
@@ -2754,11 +2779,11 @@
 				player.Teleport(true, SnapVectorToGround(self.GetOrigin() + Vector((RandomInt(250, 500) * dir), (RandomInt(250, 250) * dir), 250), 24.0), false, QAngle(), false, Vector())
 				player.SnapEyeAngles(VectorAngles(self.GetCenter() - player.EyePosition()))
 			}
-
+			
 			scope.AntiStun_Start <- function()
 			{
 				for (local ent; ent = Entities.FindByClassname(ent, "func_upgradestation"); ) ent.Disable()
-
+				
 				foreach (player in GetAllPlayers(2))
 				{
 					if (player.GetPlayerClass() == 3)
@@ -2768,18 +2793,18 @@
 						{
 							player.GetScriptScope().rocketspecialist <- weapon.GetAttribute("rocket specialist", -1.0)
 							local projspeed = player.GetScriptScope().rocketspecialist * 0.15
-
+							
 							weapon.AddAttribute("rocket specialist", 0.0, -1.0)
 							weapon.AddAttribute("projectile speed increased", 1.0 + projspeed, -1.0)
 						}
 					}
 				}
 			}
-
+			
 			scope.AntiStun_End <- function()
 			{
 				for (local ent; ent = Entities.FindByClassname(ent, "func_upgradestation"); ) ent.Enable()
-
+				
 				foreach (player in GetAllPlayers(2))
 				{
 					if (player.GetPlayerClass() == 3)
@@ -2789,16 +2814,16 @@
 						if (weapon.GetAttribute("rocket specialist", -1.0) != -1.0)
 						{
 							if (!("rocketspecialist" in player.GetScriptScope())) continue // this should never happen really
-
+							
 							weapon.AddAttribute("rocket specialist", player.GetScriptScope().rocketspecialist, -1.0)
 							weapon.RemoveAttribute("projectile speed increased")
-
+							
 							delete player.GetScriptScope().rocketspecialist
 						}
 					}
 				}
 			}
-
+			
 			AntiStun_Start()
 
 			scope.snatchercallbacks <-
@@ -2806,7 +2831,7 @@
 				OnGameEvent_recalculate_holidays = function(params)
 				{
 					AntiStun_End()
-
+					
 					delete snatchercallbacks
 				}
 
@@ -2815,10 +2840,10 @@
 					local player = GetPlayerFromUserID(params.userid)
 
 					if (player.GetTeam() != 2) return
-
+					
 					AntiStun_Start()
 				}
-
+				
 				OnGameEvent_player_death = function(params)
 				{
 					local dead_player = GetPlayerFromUserID(params.userid)
@@ -2826,7 +2851,7 @@
 					if (dead_player == self)
 					{
 						self.KeyValueFromInt("rendermode", 0)
-
+						
 						local newhatch = SpawnEntityFromTable("prop_dynamic",
 						{
 							targetname			 = "fakehatch"
@@ -2834,31 +2859,31 @@
 							model                = "models/props_mvm/mann_hatch.mdl"
 							disablebonefollowers = 1
 						})
-
+						
 						AddThinkToEnt(newhatch, "HatchLand_Think")
-
+						
 						AntiStun_End()
-
+						
 						delete snatchercallbacks
 					}
 				}
 			}
-
+			
 			foreach (name, callback in snatchercallbacks) snatchercallbacks[name] = callback.bindenv(scope)
-
+			
 			__CollectGameEventCallbacks(snatchercallbacks)
 		}
-
+		
 		if (thinkertick % 666 == 0) aggrotarget.SetOrigin(aggrodestinations[RandomInt(0, aggrodestinations.len() - 1)])
-
+		
 		if ((aggrotarget.GetOrigin() - self.GetOrigin()).Length() < 100.0)
 		{
 			local oldtarget = aggrotarget.GetOrigin()
-
+			
 			// aggrodestinations.remove(aggrodestinations.find(aggrotarget.GetOrigin())) doesn't work!
-
+			
 			local ord = 0
-
+			
 			foreach (vec in aggrodestinations)
 			{
 				if (vec.ToKVString() == oldtarget.ToKVString())
@@ -2866,12 +2891,12 @@
 					aggrodestinations.remove(ord)
 					break
 				}
-
+				
 				ord++
 			}
-
+			
 			aggrotarget.SetOrigin(coffin_locations[RandomInt(0, aggrodestinations.len() - 1)])
-
+			
 			aggrodestinations.append(oldtarget)
 		}
 
@@ -2880,12 +2905,12 @@
 			self.EmitSound("pyro_sf13_spell_generic0" + RandomInt(1, 9))
 			voicecooldown = thinkertick + RandomInt(350, 650)
 		}
-
+		
 		if (thinkertick > tauntcooldown)
 		{
 			self.SetMoveType(0, 0)
 			self.SetCustomModelOffset(Vector(0, 0, -5000))
-
+			
 			tauntmodel = SpawnEntityFromTable("prop_dynamic",
 			{
 				targetname			 = "dummymodel_" + self.entindex()
@@ -2898,18 +2923,18 @@
 				rendermode			 = 1
 				renderamt			 = 0
 			})
-
+			
 			local fakemodelglow = SpawnEntityFromTable("tf_glow",
 			{
 				target           	  = "dummymodel_" + self.entindex()
 				// GlowColor             = "153 220 255 255"
 				GlowColor			  = "125 168 196 255"
 			})
-
+			
 			fakemodelglow.AcceptInput("SetParent", "!activator", tauntmodel, tauntmodel)
-
+			
 			tauntmodel.SetCycle(0.36)
-
+			
 			SpawnEntityFromTable("prop_dynamic_ornament",
 			{
 				model                   = origmodel
@@ -2918,7 +2943,7 @@
 				disablebonefollowers	= 1
 				initialowner			= "dummymodel_" + self.entindex()
 			})
-
+			
 			SpawnEntityFromTable("prop_dynamic_ornament",
 			{
 				model                   = "models/player/items/all_class/trn_wiz_hat_scout.mdl"
@@ -2926,7 +2951,7 @@
 				disablebonefollowers	= 1
 				initialowner			= "dummymodel_" + self.entindex()
 			})
-
+			
 			local tauntprop = SpawnEntityFromTable("prop_dynamic",
 			{
 				targetname			 = "dummytauntprop_" + self.entindex()
@@ -2936,24 +2961,24 @@
 				model          		 = "models/props_mvm/mann_hatch.mdl"
 				disablebonefollowers = 1
 			})
-
+			
 			tauntprop.AcceptInput("SetParent", "!activator", tauntmodel, null)
-
+			
 			EntFireByHandle(tauntprop, "SetParentAttachment", "hand_R", 0.1, null, null)
 			EntFireByHandle(tauntprop, "RunScriptCode", "self.SetLocalOrigin(Vector(50, 10, 0))", 0.2, null, null)
 			EntFireByHandle(tauntprop, "RunScriptCode", "self.SetLocalAngles(QAngle(40, 0, 0))", 0.2, null, null)
-
+			
 			local choice = [2, 5, 7]
-
+			
 			PrecacheSound("vo/taunts/pyro/pyro_taunt_flip_int_02.mp3")
 			PrecacheSound("vo/taunts/pyro/pyro_taunt_flip_int_05.mp3")
 			PrecacheSound("vo/taunts/pyro/pyro_taunt_flip_int_07.mp3")
-
+			
 			self.EmitSound("vo/taunts/pyro/pyro_taunt_flip_int_0" + choice[RandomInt(0, 2)] + ".mp3")
 
 			tauntcooldown = thinkertick + RandomInt(2000, 3000)
 		}
-
+		
 		if (tauntmodel != null)
 		{
 			if (tauntmodel.GetCycle() >= 1.0)
@@ -2961,12 +2986,12 @@
 				local t = tauntmodel
 				tauntmodel = null
 				t.Kill()
-
+				
 				self.SetMoveType(2, 0)
 				self.SetCustomModelOffset(Vector())
 			}
 		}
-
+		
 		foreach (player in GetAllPlayers(2, [self.GetOrigin(), 250.0]))
 		{
 			local selfmins = self.GetBoundingMins() + self.GetOrigin() - Vector(5.0, 5.0, 5.0)
@@ -2982,9 +3007,9 @@
 				pushforce.Norm()
 				pushforce.z = 1.0
 				pushforce = pushforce * 270
-
+				
 				if (NetProps.GetPropEntity(player, "m_hGroundEntity") == Entities.FindByClassname(null, "worldspawn")) player.SetOrigin(player.GetOrigin() + Vector(0, 0, 24))
-
+				
 				player.RemoveFlag(1)
 				player.AddCond(115)
 
@@ -2998,30 +3023,30 @@
 	HatchLand_Think = function()
 	{
 		local scope = self.GetScriptScope()
-
+		
 		if (!("lifetick" in scope))
 		{
 			scope.lifetick <- 0
 			scope.curvel <- 0
-
+			
 			PrecacheSound("weapons/slap_swing.wav")
 		}
-
+		
 		if (lifetick < 100) curvel = 0.75
 		if (lifetick > 100) curvel -= 0.027
 		if (curvel < -0.5) curvel = -5.0
-
+		
 		self.SetOrigin(self.GetOrigin() + Vector(0, 0, curvel))
 		self.SetAbsAngles(self.GetAbsAngles() + QAngle(0, 12, 0))
-
+		
 		if (thinkertick % 7 == 0)
 		{
 			if (TraceLine(self.GetOrigin(), self.GetOrigin() - Vector(0, 0, 500), self) <= 0.1)
 			{
 				self.SetOrigin(SnapVectorToGround(self.GetOrigin()))
-
+				
 				Entities.FindByName(null, "capturezone_red").Kill()
-
+				
 				local newcapzone = SpawnEntityFromTable("func_capturezone",
 				{
 					origin         		 	= SnapVectorToGround(self.GetOrigin())
@@ -3034,39 +3059,37 @@
 					OnCapture				= "round_win,RoundWin,,0,-1"
 					OnCapture 				= "boss_deploy_relay,Trigger,,0,-1"
 				})
-
+				
 				newcapzone.KeyValueFromInt("solid", 2)
 				newcapzone.KeyValueFromString("mins", "-48 -48 -16")
 				newcapzone.KeyValueFromString("maxs", "48 48 16")
-
+				
 				EmitSoundEx({sound_name = "player/taunt_jackhammer_loop_end.wav", channel = 6, sound_level = 150, entity = self})
-
+				
 				DispatchParticleEffect("hammer_impact_button_dust2", self.GetOrigin(), Vector(0, 90, 0))
-
+				
 				NetProps.SetPropString(self, "m_iszScriptThinkFunction", "")
 				AddThinkToEnt(self, null)
-
+				
 				return 1
 			}
 		}
-
+		
 		if (thinkertick % 50 == 0) self.EmitSound("weapons/slap_swing.wav")
-
+		
 		lifetick++
-
+		
 		return -1
 	}
-
+	
 	BombHop_Think = function()
 	{
 		if (NetProps.GetPropBool(objective_resource_entity, "m_bMannVsMachineBetweenWaves")) return -1
-
+		
 		local scope = self.GetScriptScope()
-
+		
 		if (!("moving" in scope))
 		{
-			self.KeyValueFromFloat("ReturnTime", bombhoptime)
-
 			scope.moving <- false
 			scope.toapex <- true
 			scope.moveamount <- Vector()
@@ -3078,21 +3101,21 @@
 			scope.patharray <- []
 			scope.maxdistarray <- []
 			scope.activationtime <- thinkertick + 481 // always takes exactly this amount of frames for the game to start accepting path calculations since wave start
-
+			
 			scope.disttohatch_before <- 0
 			scope.disttohatch_after <- 0
-
+			
 			scope.restoredhoptime <- 0.0
 			scope.restoredhoptimeremainder <- 0.0
 			scope.restoredhoptimepenalty <- 0.0
-
-			scope.nohopping <- false
-
+			
+			scope.nohopping <- true
+			
 			scope.fullroute <- null
-
+			
 			scope.overlay_time <- -1
 			scope.hidehopoverlay <- false
-
+			
 			scope.CalculateDistance <- function()
 			{
 				local resulttable =
@@ -3101,29 +3124,29 @@
 					atspawn = false
 					recovery = false
 				}
-
+				
 				local table = {}
 				patharray = []
-
+				
 				local nearestnav = false
 				local dir = 0
-
+				
 				for (local i = 16; i <= 512; i += 16)
 				{
 					local validarea = NavMesh.GetNearestNavArea(self.GetOrigin(), i, true, false)
-
+					
 					if (!validarea) continue
 
 					nearestnav = validarea
 					break
 				}
-
+				
 				if (!nearestnav)
 				{
 					for (local i = 16; i <= 512; i += 16)
 					{
 						local validarea = NavMesh.GetNearestNavArea(self.GetOrigin(), i, false, false)
-
+						
 						if (!validarea) continue
 
 						nearestnav = validarea
@@ -3134,12 +3157,12 @@
 				foreach (nav in blocknav_array) { if (nearestnav != nav) nav.MarkAsBlocked(3) }
 
 				if (!NavMesh.GetNavAreasFromBuildPath(nearestnav, NavMesh.GetNavAreaByID(355), Vector(), 0.0, 3, false, table)) // nav area 355 is cave entrance spawn
-				{
+				{  
 					// try to find the fastest way back to our intended route
 
 					local bestlength = 10000
 					local bestreturnarea
-
+					
 					foreach (area in maxdistarray)
 					{
 						local distance = (area.GetCenter() - self.GetOrigin()).Length()
@@ -3149,16 +3172,16 @@
 							bestlength = distance
 							bestreturnarea = area
 						}
-
+						
 						else continue
 					}
-
+					
 					local radiustable = {}
-
+					
 					NavMesh.GetNavAreasInRadius(self.GetOrigin(), 500.0, radiustable)
 
 					local bestarea
-
+					
 					foreach (area in radiustable)
 					{
 						local distance = (bestreturnarea.GetCenter() - area.GetCenter()).Length()
@@ -3168,7 +3191,7 @@
 							bestlength = distance
 							bestarea = area
 						}
-
+						
 						else continue
 					}
 
@@ -3180,138 +3203,140 @@
 				}
 
 				foreach (nav in blocknav_array) nav.UnblockArea()
-
+				
 				if (table.len() == 0) { resulttable.success = false; return resulttable }
-
+				
 				for (local i = 0; i < table.len() - 1; i++) patharray.append(table["area" + i])
-
+				
 				patharray.reverse()
-
+				
 				if (patharray.len() < 2) { resulttable.atspawn = true; return resulttable }
 
 				local curarea1
 				local curarea2
-
+				
 				disttospawn = 0
 
 				for (local i = 0; i <= patharray.len() - 2; i++)
 				{
 					curarea1 = patharray[i].GetCenter()
 					curarea2 = patharray[i + 1].GetCenter()
-
+					
 					disttospawn += (curarea2 - curarea1).Length()
 				}
 
 				return resulttable
 			}
-
+			
 			scope.DetermineReturnTime <- function()
 			{
 				if (thinkertick < activationtime) return
 
 				local calcresult = CalculateDistance()
-
+				
 				if (calcresult.atspawn)
 				{
 					nohopping = true
-
+					
 					restoredhoptime = 0.0
 					restoredhoptimeremainder = 0.0
 					restoredhoptimepenalty = 0.0
-
+					
 					NetProps.SetPropFloat(self, "m_flResetTime", Time() + 60000.0)
 					NetProps.SetPropFloat(self, "m_flMaxResetTime", 0.0)
 
 					return -1
 				}
-
+				
 				if (!calcresult.success)
 				{
 					NetProps.SetPropFloat(self, "m_flResetTime", Time() + bombhoptime)
 					NetProps.SetPropFloat(self, "m_flMaxResetTime", bombhoptime)
-
+					
 					return -1
 				}
 
 				bombhoptime = RemapValClamped(disttospawn, maxdist - 1750.0, 2750.0, bombhoptime_base, bombhoptime_base * 3.0)
-
+				
 				if (bombhoptime == (bombhoptime_base * 3.0))
 				{
 					nohopping = true
-
+					
 					restoredhoptime = 0.0
 					restoredhoptimeremainder = 0.0
 					restoredhoptimepenalty = 0.0
-
+					
 					NetProps.SetPropFloat(self, "m_flResetTime", Time() + 60000.0)
 					NetProps.SetPropFloat(self, "m_flMaxResetTime", 0.0)
-
+					
 					return -1
 				}
-
+				
 				else nohopping = false
-
+				
 				restoredhoptimepenalty = 0
-
+				
 				// bombhoptime = RemapValClamped(dist, maxdist - 2000.0, 2000.0, bombhoptime_base, bombhoptime_base)
 
 				local restoredhoptimepercent = 1.0 + (restoredhoptime / bombhoptime)
-
+				
 				bombhoptime -= restoredhoptime
-
+				
 				if (bombhoptime <= 0.0) bombhoptime = 0.1
 
 				if (disttohatch_before < 4000.0) // let's not do this is we are far from hatch
 				{
 					if (disttohatch_after < disttohatch_before) bombhoptime /= 3.0 // nav clunkyness made the bomb hop towards the hatch, let's compensate by reducing hop time
 				}
-
+				
 				disttohatch_before = disttohatch_after
 
 				NetProps.SetPropFloat(self, "m_flResetTime", Time() + bombhoptime)
 				NetProps.SetPropFloat(self, "m_flMaxResetTime", bombhoptime * restoredhoptimepercent)
-
-				// 1.5x reset = 1/4, 2x reset = 1/2, 4x reset = 3/4
-
+				
+				// 1.5x reset = 1/4, 2x reset = 1/2, 4x reset = 3/4 
+				
 				// self.KeyValueFromFloat("ReturnTime", bombhoptime)
-
+				
 				restoredhoptimeremainder = restoredhoptime
 			}
-
+			
 			scope.DetermineFullPath <- function()
 			{
+				self.KeyValueFromFloat("ReturnTime", bombhoptime)
+				
 				local maxdisttable = {}
 				maxdistarray = []
-
+				
 				foreach (nav in blocknav_array) nav.MarkAsBlocked(3)
-
+				
 				NavMesh.GetNavAreasFromBuildPath(NavMesh.GetNavAreaByID(34), NavMesh.GetNavAreaByID(355), Vector(), 0.0, 3, false, maxdisttable)
-
+				
 				foreach (nav in blocknav_array) nav.UnblockArea()
-
+				
 				if (maxdisttable.len() == 0) return
 
 				for (local i = 0; i < maxdisttable.len() - 1; i++) maxdistarray.append(maxdisttable["area" + i])
-
+				
 				maxdistarray.reverse()
-
+				
 				local curarea1
 				local curarea2
-
+				
 				maxdist = 0
-
+				
 				for (local i = 0; i <= maxdistarray.len() - 2; i++)
 				{
 					curarea1 = maxdistarray[i].GetCenter()
 					curarea2 = maxdistarray[i + 1].GetCenter()
-
+					
 					maxdist += (curarea2 - curarea1).Length()
 				}
 			}
 		}
-
+		
 		if (thinkertick < activationtime) return -1 // let's not do anything until we have all necessary variables
-
+		
 		if (!maxdist) DetermineFullPath()
 
 		if (!moving && !nohopping)
@@ -3321,7 +3346,7 @@
 				restoredhoptime -= restoredhoptimepenalty
 				if (restoredhoptime < 0) restoredhoptime = 0
 			}
-
+			
 			if (NetProps.GetPropInt(self, "m_nFlagStatus") == 2 && thinkertick % 7 == 0) // dropped
 			{
 				restoredhoptime =  bombhoptime - (NetProps.GetPropFloat(self, "m_flResetTime") - Time()) + restoredhoptimeremainder
@@ -3332,7 +3357,7 @@
 		// {
 			// ClientPrint(null,3,"time until hop: " + (NetProps.GetPropFloat(self, "m_flResetTime") - Time()))
 		// }
-
+		
 		if (Time() > coffinoverlaytime)
 		{
 			if (Time() < overlay_time)
@@ -3348,31 +3373,31 @@
 							if (player.GetScriptOverlayMaterial().find("2") != null) player.SetScriptOverlayMaterial("undead_dread_overlays/bombhopalert1")
 							else													 player.SetScriptOverlayMaterial("undead_dread_overlays/bombhopalert2")
 						}
-
+						
 						else
 						{
 							if (player.GetScriptOverlayMaterial().find("2") != null) player.SetScriptOverlayMaterial("undead_dread_overlays/bombhopalert_tut1")
 							else													 player.SetScriptOverlayMaterial("undead_dread_overlays/bombhopalert_tut2")
 						}
 					}
-
+					
 					hidehopoverlay = true
 				}
 			}
-
+			
 			else if (hidehopoverlay)
 			{
 				local overlayspresent = false
-
+				
 				foreach (player in GetAllPlayers(2))
 				{
 					if (player.GetScriptOverlayMaterial() == null) continue
-
+					
 					overlayspresent = true
-
-					player.SetScriptOverlayMaterial(null)
+					
+					player.SetScriptOverlayMaterial(null)												 
 				}
-
+				
 				if (!overlayspresent) hidehopoverlay = false
 			}
 		}
@@ -3385,7 +3410,7 @@
 			v1 = Vector()
 			hopapex = Vector()
 			v2 = Vector()
-
+			
 			return -1
 		}
 
@@ -3393,37 +3418,37 @@
 		{
 			NetProps.SetPropFloat(self, "m_flResetTime", Time() + 60000.0)
 			NetProps.SetPropFloat(self, "m_flMaxResetTime", 0.0)
-
+			
 			local calcresult = CalculateDistance()
-
+			
 			if (calcresult.atspawn) return -1
-
+			
 			if (!calcresult.success)
 			{
 				NetProps.SetPropFloat(self, "m_flResetTime", Time() + bombhoptime)
 				NetProps.SetPropFloat(self, "m_flMaxResetTime", bombhoptime)
-
+				
 				return -1
 			}
-
+			
 			if (patharray.len() == 0)
 			{
 				NetProps.SetPropFloat(self, "m_flResetTime", Time() + bombhoptime)
 				NetProps.SetPropFloat(self, "m_flMaxResetTime", bombhoptime)
-
+				
 				return -1
 			}
 
 			v1 = self.GetOrigin()
 			v2 = patharray[0]
-
+			
 			if (calcresult.recovery)
 			{
 				EmitSoundEx({sound_name = "misc/ks_tier_02_kill_02.wav", channel = 6, entity = self, sound_level = 75})
 				disttohatch_before = (NavMesh.GetNavAreaByID(34).GetCenter() - v1).Length()
 				moving = true
 			}
-
+			
 			else
 			{
 				foreach (nav in patharray)
@@ -3442,11 +3467,11 @@
 					}
 				}
 			}
-
+			
 			foreach (player in GetAllPlayers(2))
 			{
 				if (!("hopalert_tutorial" in player.GetScriptScope())) player.GetScriptScope().hopalert_tutorial <- 0
-
+				
 				if (player.GetPlayerClass() == 1 || player.GetPlayerClass() == 2 || player.GetPlayerClass() == 4 || player.GetPlayerClass() == 6)
 				{
 					if (RandomInt(1, 3) == 1)
@@ -3455,74 +3480,74 @@
 						{
 							local tfclassname = class_integers[player.GetPlayerClass()] + ((player.GetPlayerClass() == 4) ? "man" : "")
 							local responseindex = tfclassname + ((player.GetPlayerClass() == 2 && player.InCond(1)) ? "_scope" : "")
-
+							
 							player.PlayScene(format("scenes/Player/%s/low/%i.vcd", tfclassname, bombhop_responses["" + responseindex][RandomInt(0, bombhop_responses["" + responseindex].len() - 1)]), -1.0)
 						}
 					}
 				}
-
+				
 				if (player.GetScriptScope().hopalert_tutorial < 3) player.GetScriptScope().hopalert_tutorial++
 			}
-
+			
 			overlay_time = Time() + 5.0
 
 			NetProps.SetPropInt(self, "m_Collision.m_nSolidType", 0) // using SetSolid and SetSolidFlags messes with the bomb's default collision
 			NetProps.SetPropInt(self, "m_Collision.m_usSolidFlags", 0)
-
+			
 			hopapex = ((v2.GetCenter() + v1) * 0.5) + Vector(0, 0, 100)
 		}
 
 		if (moving)
-		{
+		{	
 			if ((hopapex - self.GetOrigin()).Length() <= 12.0) toapex = false
 			if ((v2.GetCenter() - self.GetOrigin()).Length() <= 12.0)
 			{
 				restoredhoptime = 0
 				disttohatch_after = (NavMesh.GetNavAreaByID(34).GetCenter() - self.GetOrigin()).Length()
 				DetermineReturnTime()
-
+				
 				moving = false
 				toapex = true
 				moveamount = Vector()
 				v1 = Vector()
 				hopapex = Vector()
 				v2 = Vector()
-
+				
 				NetProps.SetPropInt(self, "m_Collision.m_nSolidType", 2)
 				NetProps.SetPropInt(self, "m_Collision.m_usSolidFlags", 140)
-
+				
 				return -1
 			}
-
+			
 			if (toapex) moveamount = (hopapex - v1) * (1.0 / 50.0)
 			else		moveamount = (v2.GetCenter() - hopapex) * (1.0 / 50.0)
 
 			self.SetAbsOrigin(self.GetOrigin() + moveamount)
 		}
-
+		
 		return -1
 	}
-
+	
 	BallHead_Think = function()
 	{
 		local scope = self.GetScriptScope()
-
+		
 		if (!("victim" in scope))
 		{
 			scope.victim <- self.GetRootMoveParent()
 			scope.jumped <- false
 			scope.endtime <- Time() + 7.5
-
+			
 			PrecacheSound("Engineer.PainCrticialDeath01")
-
+			
 			if (victim.GetPlayerClass() == 4) EntFireByHandle(victim, "RunScriptCode", "EmitSoundEx({sound_name = `Demoman.PainCrticialDeath0` + RandomInt(1, 3), origin = self.GetOrigin(), special_dsp = 14})", RandomFloat(1.0, 3.0), null, null)
-
+			
 			else EntFireByHandle(victim, "RunScriptCode", "EmitSoundEx({sound_name = class_integers[self.GetPlayerClass()] + `.PainCrticialDeath0` + RandomInt(1, 3), origin = self.GetOrigin(), special_dsp = 14})", RandomFloat(1.0, 3.0), null, null)
 
 			if (!("vistip_ballhead" in victim.GetScriptScope()))
 			{
 				victim.GetScriptScope().vistip_ballhead <- true
-				SendGlobalGameEvent("show_annotation",
+				SendGlobalGameEvent("show_annotation", 
 				{
 					id = self.entindex()
 					text = "Ballman's balls put\nyou into Ballvision!"
@@ -3534,19 +3559,19 @@
 					lifetime = 7.5
 				})
 			}
-
+			
 			scope.End <- function()
 			{
 				SendGlobalGameEvent("hide_annotation", { id = self.entindex() })
-
+				
 				// ScreenFade(victim, 255, 255, 255, 10, -1.0, 8.0, 16)
-
+				
 				victim.SetForcedTauntCam(0)
 				victim.RemoveCustomAttribute("voice pitch scale")
 				victim.RemoveCustomAttribute("head scale")
-
+				
 				delete victim.GetScriptScope().ballent
-
+				
 				NetProps.SetPropString(self, "m_iszScriptThinkFunction", "")
 				AddThinkToEnt(self, null)
 				self.Kill()
@@ -3555,81 +3580,81 @@
 			// ScreenFade(victim, 255, 255, 255, 15, -1.0, 8.0, 8)
 			victim.SetForcedTauntCam(1)
 			victim.AddCustomAttribute("voice pitch scale", 0, -1.0)
-
+			
 			scope.OnGameEvent_player_death <- function(params)
 			{
 				local dead_player = GetPlayerFromUserID(params.userid)
-
+				
 				if (dead_player == victim) End()
 			}
-
+			
 			scope.OnGameEvent_recalculate_holidays <- function(params) { End() }
 
 			__CollectGameEventCallbacks(scope)
 		}
 
 		if (ignite && !victim.InCond(22)) victim.TakeDamageEx(owner, owner, ignite_player, Vector(0, 0, 0), victim.GetOrigin(), 6.5, 8)
-
+		
 		if (!jumped)
 		{
 			if (victim.IsJumping()) endtime -= 3.75
 			jumped = true
 		}
-
+		
 		if (NetProps.GetPropEntity(victim, "m_hGroundEntity") != null) jumped = false
 
 		if (Time() >= endtime) End()
-
+		
 		return -1
 	}
-
+	
 	Ball_Think = function()
 	{
 		try { self.GetScriptScope() }
 		catch (e) { return }
-
+		
 		if (NetProps.GetPropBool(self, "m_bTouched"))
 		{
 			self.SetGravity(1.0)
-
+			
 			NetProps.SetPropString(self, "m_iszScriptThinkFunction", "")
 			AddThinkToEnt(self, null)
 			return
 		}
-
+		
 		for (local ent; ent = Entities.FindByClassnameWithin(ent, "obj_sentrygun", self.GetOrigin(), 50.0); )
 		{
 			if (ent.GetTeam() == self.GetTeam()) continue
 			if (NetProps.GetPropBool(ent, "m_bBuilding")) continue
-
+			
 			ent.ValidateScriptScope()
 			local sentryscope = ent.GetScriptScope()
-
+			
 			if ("balled" in sentryscope)
 			{
 				if (NetProps.GetPropInt(ent, "m_iUpgradeLevel") == 1) continue
-
+				
 				if (sentryscope.balled == 0) sentryscope.AttachBall()
 				else continue
 			}
-
+			
 			else AddThinkToEnt(ent, "SentryBall_Think")
-
+			
 			ent.TakeDamage(1.0, 64, self)
 
 			NetProps.SetPropString(self, "m_iszScriptThinkFunction", "")
 			self.Kill()
-
+			
 			break
 		}
-
+		
 		return -1
 	}
-
+	
 	SentryBall_Think = function()
 	{
 		local scope = self.GetScriptScope()
-
+		
 		if (!("balled" in scope))
 		{
 			scope.balled <- 0
@@ -3639,21 +3664,21 @@
 			scope.AttachBall <- function()
 			{
 				local sentryball
-
+				
 				if (!("sentryball1" in scope))
 				{
 					if (NetProps.GetPropInt(self, "m_iUpgradeLevel") > 1) blocknextshot = true
-
+					
 					scope.sentryball1 <- SpawnEntityFromTable("prop_dynamic",
 					{
 						origin             	 = self.GetOrigin()
 						disablebonefollowers = 1
 						model 			   	 = "models/weapons/w_models/w_baseball.mdl"
 					})
-
+					
 					sentryball = sentryball1
 				}
-
+				
 				else if (!("sentryball2" in scope))
 				{
 					balled = 1
@@ -3663,69 +3688,69 @@
 						disablebonefollowers = 1
 						model 			   	 = "models/weapons/w_models/w_baseball.mdl"
 					})
-
+					
 					sentryball = sentryball2
 				}
-
+				
 				else return
-
+				
 				local sound = "weapons/sentry_damage" + RandomInt(1, 4) + ".wav"
-
+				
 				EmitSoundEx({sound_name = sound, entity = self, channel = 6, sound_level = 150})
 				EmitSoundEx({sound_name = sound, entity = self, channel = 6, sound_level = 150})
 				EmitSoundEx({sound_name = sound, entity = self, channel = 6, sound_level = 150})
 
 				sentryball.AcceptInput("SetParent", "!activator", self, null)
-
+				
 				local attach
-
+				
 				if (NetProps.GetPropInt(self, "m_iUpgradeLevel") == 1) attach = "muzzle"
 				else
 				{
 					if ("sentryball1" in scope) attach = "muzzle_r"
 					if ("sentryball2" in scope)	attach = "muzzle_l"
 				}
-
+				
 				EntFireByHandle(sentryball, "SetParentAttachment", attach, 0.1, null, null)
 			}
-
+			
 			AttachBall()
 		}
-
+		
 		if ((balled == 0 && NetProps.GetPropInt(self, "m_iUpgradeLevel") == 1) || balled == 1) NetProps.SetPropInt(self, "m_iState", 1)
 
 		if (self.GetHealth() > lasthealth || thinkertick >= endtime)
 		{
 			sentryball1.Kill()
 			if ("sentryball2" in scope) sentryball2.Kill()
-
+			
 			NetProps.SetPropInt(self, "m_iState", 2)
-
+			
 			self.TerminateScriptScope()
 			NetProps.SetPropString(self, "m_iszScriptThinkFunction", "")
 			AddThinkToEnt(self, null)
 			return
 		}
-
+	
 		lasthealth = self.GetHealth()
 
 		return -1
 	}
-
+	
 	WeaponGallery_Think = function()
 	{
 		for (local ent; ent = Entities.FindByName(ent, "gallery_*"); ) ent.SetAbsAngles(ent.GetAngles() + QAngle(0, 1, 0))
-
+		
 		foreach (player in GetAllPlayers(2, [Vector(525, 5150, 0), 450.0]))
 		{
 			if (player.IsFakeClient()) continue
-
-			local scope = player.GetScriptScope()
-
+			
+			local scope = player.GetScriptScope()	
+			
 			local invalid = false
 			local notmod = false
 			local allowed = true
-
+			
 			if (!("inmodmenu" in scope))
 			{
 				scope.inmodmenu <- false
@@ -3736,10 +3761,10 @@
 					loch = false
 					bow = false
 				}
-
+				
 				scope.hashatchwep <- false
 			}
-
+			
 			if (scope.modmenucooldown > Time())
 			{
 				player.RemoveHudHideFlags(4)
@@ -3756,17 +3781,17 @@
 					mask = 33570827
 					ignore = player
 				}
-
+				
 				TraceLineEx(tracetable)
-
+				
 				scope.lookingat = tracetable.enthit.GetName()
-
+				
 				if (startswith(scope.lookingat, "gallery"))
 				{
 					scope.inmodmenu = true
 					player.AddCustomAttribute("no_attack", 1, 0.5)
 					player.AddHudHideFlags(4)
-
+					
 					if (!scope.completedall)
 					{
 						ClientPrint(player, 4, "Complete all six waves to earn access to these items")
@@ -3775,7 +3800,7 @@
 						player.RemoveHudHideFlags(4)
 						continue
 					}
-
+					
 					switch (scope.lookingat.slice(8))
 					{
 						case "loch":
@@ -3785,12 +3810,12 @@
 								ClientPrint(player, 4, "Only Demoman can equip this")
 								invalid = true
 							}
-
+							
 							else player.SetScriptOverlayMaterial("undead_dread_overlays/weaponmod_loch")
 
 							break
 						}
-
+						
 						case "bow":
 						{
 							if (player.GetPlayerClass() != 2)
@@ -3798,12 +3823,12 @@
 								ClientPrint(player, 4, "Only Sniper can equip this")
 								invalid = true
 							}
-
+							
 							else player.SetScriptOverlayMaterial("undead_dread_overlays/weaponmod_bow")
-
+							
 							break
 						}
-
+						
 						case "hatch":
 						{
 							player.SetScriptOverlayMaterial("undead_dread_overlays/weaponmod_hatch")
@@ -3811,7 +3836,7 @@
 							break
 						}
 					}
-
+					
 					if (invalid)
 					{
 						scope.lookingat = null
@@ -3820,7 +3845,7 @@
 						continue
 					}
 				}
-
+				
 				else
 				{
 					scope.lookingat = null
@@ -3828,7 +3853,7 @@
 					player.RemoveHudHideFlags(4)
 				}
 			}
-
+			
 			if (scope.inmodmenu)
 			{
 				if (NetProps.GetPropInt(player, "m_afButtonPressed") & 1)
@@ -3838,26 +3863,26 @@
 						if (!scope.hashatchwep)
 						{
 							scope.hashatchwep = true
-
+							
 							local classname
-
+							
 							if (player.GetPlayerClass() == 1) classname = "tf_weapon_bat"
 							else if (player.GetPlayerClass() == 8) classname = "tf_weapon_knife"
 							else if (player.GetPlayerClass() == 9) classname = "tf_weapon_wrench"
 							else classname = "tf_weapon_club"
-
+							
 							local hatchwep = player.GetWeapon(classname, 30758)
-
+							
 							local vm = NetProps.GetPropEntity(player, "m_hViewModel")
 
 							NetProps.SetPropInt(hatchwep, "m_nRenderMode", 1)
 							NetProps.SetPropInt(hatchwep, "m_clrRender", 0)
-
+							
 							AddThinkToEnt(hatchwep, "HatchVM_Think")
-
+							
 							scope.modmenucooldown = Time() + 3.0
 						}
-
+						
 						else
 						{
 							scope.modmenucooldown = Time() + 3.0
@@ -3865,7 +3890,7 @@
 							player.ForceRespawn()
 						}
 					}
-
+					
 					else
 					{
 						EquipWeaponMod.call(scope, scope.lookingat.slice(8))
@@ -3874,24 +3899,24 @@
 					}
 				}
 			}
-
+			
 			else player.SetScriptOverlayMaterial(null)
 		}
 	}
-
+	
 	HatchVM_Think = function()
 	{
 		try { self.GetScriptScope() }
 		catch (e) { return }
-
+		
 		local scope = self.GetScriptScope()
 		local owner = NetProps.GetPropEntity(self, "m_hOwner")
 		local mainvm = NetProps.GetPropEntity(owner, "m_hViewModel")
-
+		
 		if (!("vm" in scope))
 		{
 			self.AddAttribute("crit mod disabled", 0.0, -1.0)
-
+			
 			scope.vm <- Entities.CreateByClassname("obj_teleporter")
 			vm.SetAbsOrigin(self.GetOrigin())
 			vm.DispatchSpawn()
@@ -3911,21 +3936,21 @@
 				// disableshadows		 = 1
 				// model 			   	 = self.GetModelName()
 			// })
-
+			
 			// scope.hatchwepprop <- Entities.CreateByClassname("prop_dynamic")
-
+			
 			// hatchwepprop.SetAbsOrigin(self.GetOrigin())
 			// hatchwepprop.SetModelScale(0.06, -1.0)
 			// hatchwepprop.SetAbsAngles(QAngle(0, 0, 120))
 			// hatchwepprop.SetModel("models/props_mvm/mann_hatch.mdl")
-
+			
 			// hatchwepprop.KeyValueFromInt("disablebonefollowers", 1)
 			// hatchwepprop.KeyValueFromInt("disableshadows", 1)
-
+			
 			// NetProps.SetPropInt(hatchwepprop, "m_fEffects", 16)
-
+			
 			// hatchwepprop.DispatchSpawn()
-
+			
 			scope.hatchwepprop <- SpawnEntityFromTable("prop_dynamic",
 			{
 				origin             	 = self.GetOrigin()
@@ -3936,26 +3961,26 @@
 				solid				 = 0
 				model 			   	 = "models/props_mvm/mann_hatch.mdl"
 			})
-
+			
 			NetProps.SetPropBool(vm, "m_bClientSideAnimation", false)
-
+			
 			vm.AcceptInput("SetParent", "!activator", mainvm, null)
-
+			
 			hatchwepprop.AcceptInput("SetParent", "!activator", vm, null)
-
+			
 			EntFireByHandle(hatchwepprop, "SetParentAttachmentMaintainOffset", "weapon_bone", 0.1, null, null)
 			EntFireByHandle(hatchwepprop, "RunScriptCode", "self.SetLocalOrigin(Vector())", 0.2, null, null)
 			EntFireByHandle(hatchwepprop, "RunScriptCode", "self.SetLocalAngles(QAngle(0, 0, 180))", 0.2, null, null)
-
+			
 			scope.wm <- owner.GetWearable("models/props_mvm/mann_hatch.mdl", false, "effect_hand_R", null)
 
 			NetProps.SetPropInt(self, "m_fEffects", 48)
 			NetProps.SetPropInt(wm, "m_fEffects", 48)
 			NetProps.SetPropInt(vm, "m_fEffects", 48)
 			NetProps.SetPropInt(hatchwepprop, "m_fEffects", 48)
-
+			
 			wm.SetModelScale(0.06, -1.0)
-
+			
 			vm.SetPlaybackRate(1.0)
 
 			SetDestroyCallback(self, function()
@@ -3966,16 +3991,16 @@
 					scope.wm.Kill()
 					scope.vm.Kill()
 				}
-
+				
 				catch (e) {}
 			})
 		}
-
+		
 		if (!vm.IsValid()) return -1
-
+		
 		vm.StudioFrameAdvance()
 		vm.DispatchAnimEvents(vm)
-
+		
 		if (owner.GetActiveWeapon() != self || owner.IsTaunting())
 		{
 			vm.DisableDraw()
@@ -3983,11 +4008,11 @@
 			hatchwepprop.DisableDraw()
 			return -1
 		}
-
+		
 		vm.EnableDraw()
 		wm.EnableDraw()
 		hatchwepprop.EnableDraw()
-
+		
 		if (vm.GetSequence() != self.GetSequence())
 		{
 			vm.SetSequence(self.GetSequence())
@@ -3998,16 +4023,16 @@
 		if (vm.GetCycle() >= 1.0) vm.SetCycle(0.0)
 
 		// if (thinkertick % 7 == 0) ClientPrint(null,3,"" + self.GetSequence())
-
+		
 		return -1
 	}
-
+	
 	DisplayLog_Think = function()
 	{
 		for (local i = 1; i <= Constants.Server.MAX_PLAYERS; i++)
 		{
 			local player = PlayerInstanceFromIndex(i)
-
+			
 			if (NetProps.GetPropString(player, "m_szNetworkIDString") == "[U:1:95064912]")
 			{
 				if (NetProps.GetPropInt(player, "m_afButtonPressed") & 8192)
@@ -4019,7 +4044,7 @@
 							ClientPrint(player,3,"over")
 							break
 						}
-
+						
 						ClientPrint(player,3,"" + FileToString(logname + i))
 					}
 				}
@@ -4041,16 +4066,15 @@ catch (e) { ClientPrint(null,3,"Failed to locate or parse `pea.nut` file. Some o
 if (!("PEA_ONETIME" in getroottable()))
 {
 	::PEA_ONETIME <- // declare these variables only once on initial load, don't update them on any future loads
-	{
-		wavehaszombies = false
+	{	
 		coffins_active = false
 		suppress_waveend_music = false
 		secretwave_unlocked = false
 		samurai_spawn = null
 		samurai_spawn_minion = null
 		guaranteedbranch = false
-
-		coffintime_cc = SpawnEntityFromTable("color_correction",
+		
+		coffintime_cc = SpawnEntityFromTable("color_correction", 
 		{
 			StartDisabled    = 1
 			maxfalloff       = -1
@@ -4060,34 +4084,34 @@ if (!("PEA_ONETIME" in getroottable()))
 			filename         = "materials/colorcorrection/zombie_cc25.raw"
 		})
 	}
-
+	
 	foreach (thing, var in PEA_ONETIME) getroottable()[thing] <- getroottable()["PEA_ONETIME"][thing]
 
 	PrecacheEntityFromTable({ classname = "info_particle_system", effect_name = "m_brazier_flame" })
 
 	samurai_spawn = Entities.FindByName(null, "spawnbot_samurai")
 	samurai_spawn_minion = Entities.FindByName(null, "spawnbot_samurai_2")
-
+	
 	coffintime_cc.KeyValueFromString("classname", "entity_sign") // this makes the entity preserve itself on mission reloads
-
+	
 	PrecacheSound("misc/ks_tier_02_kill_02.wav")
-
+	
 	DisconnectNavAreas(
 	[
 		[180, 414], [189, 39], [189, 2077], [274, 581], [318, 1134], [3264, 1786], [406, 332], [406, 404], [406, 4017], [485, 169], [579, 39], [736, 5381], [736, 5382], [979, 5381], [982, 581], [1134, 44], [1178, 303], [1278, 140], [1278, 902], [2417, 457], [3160, 1763], [3177, 3188], [3178, 3188],
 		[3179, 1763], [3324, 1076], [3379, 5365], [4400, 5381], [4406, 5381], [5725, 140], [5726, 140], [5727, 140], [5728, 140], [5307, 204], [5365, 3379], [910, 5827], [910, 5828], [145, 5683], [145, 5684], [234, 5684], [360, 368], [481, 2693], [481, 5684], [481, 5684]
 	])
-
+	
 	ConnectNavAreas([[116, 123]])
-
+	
 	UnblockNavAreas([85, 200, 297, 298, 354, 356, 454, 623, 792, 795, 1075, 1078, 1533, 1540, 1545, 1546, 1547, 2342, 2343, 2371, 2388, 2389])
-
+	
 	foreach (player in GetAllPlayers(2))
 	{
 		if (player.IsFakeClient()) continue
-
+		
 		player.ValidateScriptScope()
-
+		
 		if (!(IsInLog.call(player.GetScriptScope()).found)) AddToLog.call(player.GetScriptScope())
 	}
 }
@@ -4100,11 +4124,11 @@ foreach (sound in coffin_sounds) PrecacheSound(sound)
 if (!secretwave_unlocked)
 {
 	NetProps.SetPropInt(objective_resource_entity, "m_nMannVsMachineMaxWaveCount", 5)
-
+	
 	if (Wave == 6)
 	{
 		NetProps.SetPropInt(objective_resource_entity, "m_nMannVsMachineWaveCount", 5)
-
+		
 		EntFire("FrontUpgradeStation", "Enable")
 		EntFire("FrontUpgradeGate", "Open")
 	}
@@ -4115,7 +4139,7 @@ for (local ent; ent = Entities.FindByClassname(ent, "func_nav_prefer"); ) ent.Ki
 for (local ent; ent = Entities.FindByClassname(ent, "func_nav_avoid"); )
 {
 	local id = NetProps.GetPropInt(ent, "m_iHammerID")
-
+	
 	if (id == 1920728 || id == 1941647 || id == 1395198 || id == 1396096)
 	{
 		ent.KeyValueFromString("targetname", "nav_avoid_dontdisable")
@@ -4131,14 +4155,14 @@ for (local ent; ent = Entities.FindByName(ent, "bombpath_holograms_clear_relay")
 
 // for (local ent; ent = Entities.FindByModel(ent, "models/props_mvm/hologram_projector.mdl"); ) ent.Disable()
 // for (local ent; ent = Entities.FindByModel(ent, "models/props_mvm/robot_hologram.mdl"); ) ent.Disable()
-
+	
 SpawnNavBrush("nav_avoid_giant_upgradestation_dontdisable", Vector(-100, -550, 300), "-250 -250 -250", "250 250 250", "bot_giant")
 
 for (local i = 3; i <= 6; i++) EntFire("sentrynest_right" + i, "Disable")
 for (local i = 2; i <= 6; i++) EntFire("sentrynest_left" + i, "Disable")
-
+	
 if (!(!guaranteedbranch)) cross_connections[1].remove(cross_connections[1].find(guaranteedbranch))
-
+	
 // if (Wave == 7) EntFire("spawnbot_tunnel", "Disable", null, -1.0, null)
 // else 		   EntFire("spawnbot_tunnel", "Enable", null, -1.0, null)
 
@@ -4198,12 +4222,12 @@ if (!wavewon)
 		damagemodel = 0
 		spawnflags  = 0
 	})
-
+	
 	cashcollect.KeyValueFromInt("solid", 2)
 	cashcollect.KeyValueFromString("mins", "-150 -1000 -500")
 	cashcollect.KeyValueFromString("maxs", "150 0 500")
 }
-
+	
 if (Wave != 5)
 {
 	if (!wavewon) DetermineBombPath(1)
@@ -4259,77 +4283,18 @@ else
 	CreatePathHologram(Vector(-200, 1600, 100), QAngle(0, 120, 0))
 }
 
-switch (Wave)
-{
-	case 1:
-	{
-		wavehaszombies = false
-		// AddToIcon("soldier_conch", 12)
-		// AddToIcon("sniper_bow_stun", 8)
-		break
-	}
-	case 2:
-	{
-		wavehaszombies = true
-		AddToIcon("demo_fire_2", 8)
-		AddToIcon("pyro_flare", 16)
-		break
-	}
-	case 3:
-	{
-		wavehaszombies = true
-		break
-	}
-	case 4:
-	{
-		wavehaszombies = true
-		break
-	}
-	case 5:
-	{
-		wavehaszombies = false
+ModifyWaveBar(true)
 
-		if (!secretwave_unlocked)
-		{
-			NetProps.SetPropFloat(gamerules_entity, "m_flRestartRoundTime", Time())
-			EnableSpawn("secretwave")
-		}
-
-		else
-		{
-			DisableSpawn("secretwave")
-
-			UnhideIcon("hatch_nys", 9)
-			UnhideIcon("pyro_giant", 25)
-			UnhideIcon("medic_giant", 9)
-			UnhideIcon("scout_giant_fast", 9)
-			// SetTotalEnemyCount(13)
-		}
-
-		break
-	}
-	case 6:
-	{
-		wavehaszombies = false
-
-		// AddToIcon("soldier_crit", 26)
-		// AddToIcon("scout_bonk", 30)
-		// AddToIcon("sniper_bow_stun", 12)
-
-		break
-	}
-}
-
-if (wavehaszombies)
+if (WaveHasIcon("dead_blu_lite"))
 {
 	if (Entities.FindByModel(null, "models/workshop/player/items/spy/taunt_the_crypt_creeper/taunt_the_crypt_creeper.mdl") == null)
 	{
 		for (local ent; ent = Entities.FindByName(ent, "spawnbot_coffin*"); )
 		{
 			ent.Disable()
-
+			
 			ent.ValidateScriptScope()
-
+			
 			local coffinprop = SpawnEntityFromTable("prop_dynamic",
 			{
 				targetname		   	 = "coffin_prop"
@@ -4338,12 +4303,12 @@ if (wavehaszombies)
 				disablebonefollowers = 1
 				model 			   	 = "models/workshop/player/items/spy/taunt_the_crypt_creeper/taunt_the_crypt_creeper.mdl"
 			})
-
+			
 			coffinprop.ValidateScriptScope()
 			coffinprop.GetScriptScope().associated_spawn_ent <- ent
-
+			
 			NetProps.SetPropBool(coffinprop, "m_bClientSideAnimation", false)
-
+			
 			AddThinkToEnt(coffinprop, "CoffinProp_Think")
 		}
 	}
@@ -4352,24 +4317,24 @@ if (wavehaszombies)
 else { for (local ent; ent = Entities.FindByModel(ent, "models/workshop/player/items/spy/taunt_the_crypt_creeper/taunt_the_crypt_creeper.mdl"); ) ent.Kill() }
 
 if (coffins_active) ToggleCoffins()
-
+	
 for (local ent; ent = Entities.FindByClassname(ent, "point_viewcontrol"); ) ent.Kill()
 
 for (local i = 1; i <= Constants.Server.MAX_PLAYERS; i++)
 {
 	local player = PlayerInstanceFromIndex(i)
-
+	
 	if (player == null) continue
 	if (player.IsFakeClient()) continue
 	if (player.GetTeam() != 2) continue
-
+	
 	player.ValidateScriptScope()
 	player.SetScriptOverlayMaterial(null)
-
+	
 	local scope = player.GetScriptScope()
 
 	if (!wavewon) { if ("modsactive" in scope) { foreach (name, status in scope.modsactive) { if (status) EquipWeaponMod.call(scope, name, true) } } }
-
+	
 	scope.completedall <- IsInLog.call(scope).completedall
 	if (scope.completedall)
 	{
@@ -4379,7 +4344,7 @@ for (local i = 1; i <= Constants.Server.MAX_PLAYERS; i++)
 		{
 			scope.NewFeaturesTutorial <- function()
 			{
-				SendGlobalGameEvent("show_annotation",
+				SendGlobalGameEvent("show_annotation", 
 				{
 					id = self.entindex()
 					text = "Congratulations on beating\nall the waves! You now have\naccess to new weapon features!"
@@ -4392,16 +4357,16 @@ for (local i = 1; i <= Constants.Server.MAX_PLAYERS; i++)
 					show_effect = false
 					lifetime = 7.5
 				})
-
+				
 				NewFeaturesTutorial = null
 			}
-
+			
 			scope.NewFeaturesTutorial()
 		}
 	}
 
 	if ("hasducky" in scope) delete scope.hasducky
-
+	
 	player.AddCustomAttribute("vision opt in flags", 2, -1)
 }
 
@@ -4429,13 +4394,13 @@ if (debug)
 	{
 		local player = PlayerInstanceFromIndex(i)
 		if (NetProps.GetPropString(player, "m_szNetworkIDString") == "[U:1:95064912]")
-		{
+		{			
 			// player.Teleport(true, Vector(1000, -1200, 0), false, QAngle(), false, Vector())
 
 			// player.SetScriptOverlayMaterial("coffin_warning_overlay")
 			// player.SetScriptOverlayMaterial("undead_dread_overlays/weaponmod_loch")
 			// player.AddHudHideFlags(4)
-
+			
 			// EntFireByHandle(player, "SetScriptOverlayMaterial", "", 0.0, null, null)
 			// EntFireByHandle(player, "RunScriptCode", "self.RemoveHudHideFlags(4)", 3.0, null, null)
 		}


### PR DESCRIPTION
General:
  Attempt at fixing certain cosmetics not being attached properly to players
  Reduced likelihood of squads getting stuck inside the Tank spawn room
  Fixed issue where killing the bomb carrier too soon into the start of the wave would trigger the bomb's hopping behavior when it shouldn't.
  Fixed issue with zombified bots' ragdolls missing body parts.
  Fixed issue where killing Samurai Soldier in the midst of his duplicating animation would make his particles persist.

Wave 1:
  Reduced WaitBetweenSpawns for ending Scattergun Scout support from 2.5 to 2.25.

Wave 3:
  Reduced WaitBetweenSpawns of first Soldier support from 8 to 7.
  Increased skill of Heavies squadded with Giant Pyros from Normal to Hard.
  Reduced WaitBetweenSpawns of Soldier/Major League Scout support from 10 to 9.

Wave 4:
  The last two Crit Giant Deflector Heavies now spawn 10 seconds faster.

Bonus wave:
  Hatch Snatcher can no longer be sapped.

Wave 5:
  The last Charged Soldier subwave will now end prematurely if all other subwaves have ended.