### PR TITLE
Update Catastrophic Conjuring, Light up the Night

### DIFF
--- a/scripts/population/mvm_creepside_b2_adv_catastrophic_conjuring.pop
+++ b/scripts/population/mvm_creepside_b2_adv_catastrophic_conjuring.pop
@@ -2,6 +2,7 @@
 #base robot_standard.pop
 #base robot_giant.pop
 #base robot_stardust_vscript.pop
+#base judge_restricts_v2.pop
 //#base overclocks_stardust.pop
 
 WaveSchedule
@@ -677,6 +678,7 @@ WaveSchedule
                 {
                     try IncludeScript(format(`conjuring_scripts/%s`, path), _root) catch(e) printl(e)
                 }
+                IncludeCustom(`mvm_creepside_b2_adv_catastrophic_conjuring_tags.nut`)
                 IncludeCustom(`creepside_adv.nut`)
                 ClientPrint(null,3,`\x0799CCFMWARNING! The bomb will STOP RESETTING when the wave nears the end!`)
 
@@ -1062,6 +1064,7 @@ WaveSchedule
                 {
                     try IncludeScript(format(`conjuring_scripts/%s`, path), _root) catch(e) printl(e)
                 }
+                IncludeCustom(`mvm_creepside_b2_adv_catastrophic_conjuring_tags.nut`)
                 IncludeCustom(`creepside_adv.nut`)
 
                 MissionAttrs
@@ -1437,6 +1440,7 @@ WaveSchedule
                 {
                     try IncludeScript(format(`conjuring_scripts/%s`, path), _root) catch(e) printl(e)
                 }
+                IncludeCustom(`mvm_creepside_b2_adv_catastrophic_conjuring_tags.nut`)
                 IncludeCustom(`creepside_adv.nut`)
 
                 MissionAttrs
@@ -2045,6 +2049,7 @@ WaveSchedule
                 {
                     try IncludeScript(format(`conjuring_scripts/%s`, path), _root) catch(e) printl(e)
                 }
+                IncludeCustom(`mvm_creepside_b2_adv_catastrophic_conjuring_tags.nut`)
                 IncludeCustom(`merasmus_boss.nut`)
                 IncludeCustom(`creepside_adv.nut`)
 
@@ -2116,15 +2121,16 @@ WaveSchedule
                 Attributes UseBossHealthBar
                 ClassIcon timer_lite	
                 Health 300
+                Health 600 [$SIGSEGV] 
                 Name "Timer"
                 WeaponRestrictions MeleeOnly
                 Tag "bot_timer"
-                Tag "bot_dummy"
                 // Tag "popext_spawnhere|-1214.1 3923.5 554.7"
                 // Tag "popext_usecustommodel|models/empty.mdl"
                 CharacterAttributes
                 {
                     "active health degen" -1
+                    "is suicide counter" 1 [$SIGSEGV] 
                     "dmg taken from bullets increased" 0
                     "dmg taken from fire increased" 0
                     "dmg taken from crit increased" 0
@@ -2137,7 +2143,6 @@ WaveSchedule
                     "airblast vertical vulnerability multiplier" 0
                     "rage giving scale" 0
                     "cannot be backstabbed" 1
-                    "dmg from melee increased" 0
 
                     "voice pitch scale" 0
                     "no_attack" 1

--- a/scripts/population/mvm_creepside_b2_adv_catastrophic_conjuring.pop
+++ b/scripts/population/mvm_creepside_b2_adv_catastrophic_conjuring.pop
@@ -2,7 +2,7 @@
 #base robot_standard.pop
 #base robot_giant.pop
 #base robot_stardust_vscript.pop
-#base judge_restricts_v2.pop
+//#base judge_restricts_v2.pop
 //#base overclocks_stardust.pop
 
 WaveSchedule
@@ -593,7 +593,7 @@ WaveSchedule
     //             {
     //                 try IncludeScript(format(`conjuring_scripts/%s`, path), _root) catch(e) printl(e)
     //             }
-    //             IncludeCustom(`mvm_creepside_b2_adv_catastrophic_conjuring_tags.nut`)
+    //             
     //             IncludeCustom(`creepside_adv.nut`)
     //             ClientPrint(null,3,`\x0799CCFMWARNING! The bomb will STOP RESETTING when the wave nears the end!`)
 
@@ -678,7 +678,7 @@ WaveSchedule
                 {
                     try IncludeScript(format(`conjuring_scripts/%s`, path), _root) catch(e) printl(e)
                 }
-                IncludeCustom(`mvm_creepside_b2_adv_catastrophic_conjuring_tags.nut`)
+                
                 IncludeCustom(`creepside_adv.nut`)
                 ClientPrint(null,3,`\x0799CCFMWARNING! The bomb will STOP RESETTING when the wave nears the end!`)
 
@@ -1064,7 +1064,7 @@ WaveSchedule
                 {
                     try IncludeScript(format(`conjuring_scripts/%s`, path), _root) catch(e) printl(e)
                 }
-                IncludeCustom(`mvm_creepside_b2_adv_catastrophic_conjuring_tags.nut`)
+                
                 IncludeCustom(`creepside_adv.nut`)
 
                 MissionAttrs
@@ -1440,7 +1440,7 @@ WaveSchedule
                 {
                     try IncludeScript(format(`conjuring_scripts/%s`, path), _root) catch(e) printl(e)
                 }
-                IncludeCustom(`mvm_creepside_b2_adv_catastrophic_conjuring_tags.nut`)
+                
                 IncludeCustom(`creepside_adv.nut`)
 
                 MissionAttrs
@@ -2049,7 +2049,7 @@ WaveSchedule
                 {
                     try IncludeScript(format(`conjuring_scripts/%s`, path), _root) catch(e) printl(e)
                 }
-                IncludeCustom(`mvm_creepside_b2_adv_catastrophic_conjuring_tags.nut`)
+                
                 IncludeCustom(`merasmus_boss.nut`)
                 IncludeCustom(`creepside_adv.nut`)
 

--- a/scripts/population/mvm_whitecliff_event_rc2_exp_light_up_the_night.pop
+++ b/scripts/population/mvm_whitecliff_event_rc2_exp_light_up_the_night.pop
@@ -9260,12 +9260,10 @@ Real?
 		WaveSpawn
 		{
 			Name	ezclear
-			WaitForAllSpawned	wave5b
 			Support		Limited
 			TotalCount	0
 			MaxActive	0
 			SpawnCount	0
-			WaitBeforeStarting	25
 			FirstSpawnMessage	"{yellow}[NOTICE] Typing '!hiderank' in chat will disable the rank from your hud. Use this if you have a missing texture on your screen!"
 			FirstSpawnWarningSound	"ui/cyoa_ping_available.wav"
 		}

--- a/scripts/vscripts/conjuring_scripts/merasmus_boss.nut
+++ b/scripts/vscripts/conjuring_scripts/merasmus_boss.nut
@@ -7,6 +7,8 @@
 // all by stardustspy with some help
 //Night Fight Arena - Clash Royale OST Soundtrack Theme (Season 63)
 
+::MASK_SOLID <- 33570827
+
 PrecacheModel("models/props_mvm/robot_spawnpoint_warning.mdl")
 PrecacheModel("models/empty.mdl")
 PrecacheModel("models/bots/skeleton_sniper/skeleton_sniper_fixed.mdl")
@@ -105,7 +107,7 @@ function TimerTag()
             local origin = bot.GetOrigin()
             local nav_delete = {}
 
-            bot.Teleport(true, Vector(-355, 2233, 673), false, QAngle(), false, Vector())
+            bot.Teleport(true, Vector(-1139, 3988, 544), false, QAngle(), false, Vector())
             bot.DisableDraw()
             bot.SetMoveType(MOVETYPE_NOCLIP + MOVETYPE_FLY, MOVECOLLIDE_DEFAULT) // completely stops a player in place
             bot.SetCollisionGroup(13)
@@ -279,6 +281,7 @@ function RespawnBombCarrier()
         "obj_sentrygun" : 1
         "obj_dispenser": 1
         "obj_teleporter" : 1
+        "entity_medigun_shield" : 1
     }
 
     SetPropBool(self, "m_bForcedSkin", true)
@@ -535,7 +538,7 @@ function RespawnBombCarrier()
         end    = eyepos_end
         hullmin = Vector(-10, -10, -10)
         hullmax = Vector(10, 10, 10)
-        //mask = -1 
+        mask = 33636363
         ignore = self
     }
     TraceHull(eyetrace)
@@ -543,7 +546,6 @@ function RespawnBombCarrier()
     function SpawnLaser(ent, rand_intmin, rand_intmax) 
     {
         local sound_range = (40 + (20 * log10(300 / 36.0))).tointeger();
-        
         
         local target = SpawnEntityFromTable("info_target", 
         {
@@ -638,6 +640,27 @@ function RespawnBombCarrier()
             {
                 local enemy = eyetrace.enthit
 
+                if (enemy.GetClassname() == "entity_medigun_shield")
+                {
+                    printl(enemy)
+                    local shield_owner = enemy.GetOwner()
+                    printl(shield_owner)
+                    local rage = shield_owner.GetRageMeter()
+
+                    if (laser_mode == 1)
+                    {
+                        shield_owner.AddCustomAttribute("increase buff duration HIDDEN", 0.17, 0.09)
+                    }
+                    else 
+                    { 
+                        shield_owner.AddCustomAttribute("increase buff duration HIDDEN", 0.39, 0.3)
+                    }
+
+                    // NetProps.SetPropBool(shield_owner, "m_bRageDraining", false)
+                    // shield_owner.SetRageMeter(33)
+                    // NetProps.SetPropFloat(shield_owner, "m_flRageMeter", 0)
+                }
+                
                 if (enemy.GetTeam() != self.GetTeam() && enemy.GetTeam() != TEAM_SPECTATOR)
                 {
                     if (laser_mode == 0)
@@ -1166,6 +1189,7 @@ function RespawnBombCarrier()
         "obj_sentrygun" : 1
         "obj_dispenser": 1
         "obj_teleporter" : 1
+        "entity_medigun_shield" : 1
     }
     for (local ent; ent = FindInSphere(ent, origin, 150);)
     {
@@ -1224,6 +1248,7 @@ function RespawnBombCarrier()
         "obj_sentrygun" : 1
         "obj_dispenser": 1
         "obj_teleporter" : 1
+        "entity_medigun_shield" : 1
     }
 
     if (touched == true)
@@ -1367,6 +1392,7 @@ function ApplyThunderThink(player, caster)
             "obj_sentrygun" : 1
             "obj_dispenser": 1
             "obj_teleporter" : 1
+            "entity_medigun_shield" : 1
         }
         //ambient\energy\electric_loop.wav
         local sound_range = (40 + (20 * log10(3000 / 36.0))).tointeger();
@@ -1383,7 +1409,7 @@ function ApplyThunderThink(player, caster)
             end    = thunder_cloud.GetOrigin() + Vector(0, 0, -380)
             hullmin = Vector(-10, -10, -10)
             hullmax = Vector(10, 10, 10)
-            //mask = -1 
+            mask = -1 
             ignore = self
         }
 
@@ -1918,6 +1944,7 @@ function ApplyThunderThink(player, caster)
         "obj_sentrygun" : 1
         "obj_dispenser": 1
         "obj_teleporter" : 1
+        "entity_medigun_shield" : 1
     }
 
     function BossSetup() 


### PR DESCRIPTION
- Catastrophic Conjuring
  - Add projectile shield drain to Merasmus.
  - Add sigmod compatibility fix to timer bot.
- Light up the Night
  - Remove the delay from the `!hiderank` notification.
