### PR TITLE
Update custom_weapons_randomguy.pop

### DIFF
--- a/scripts/population/custom_weapons_randomguy.pop
+++ b/scripts/population/custom_weapons_randomguy.pop
@@ -66,6 +66,7 @@ WaveSchedule
 		// "reload time increased"		1.2
 		// "fire rate bonus"			1	// remove FaN's fire rate bonus.
 		// "hand scale"				1.5	// hear me out...
+		"damage bonus"					1.25
 		"add attributes when active"	"hand scale|1.5"	// Now shouldn't be passive.
 	}
 


### PR DESCRIPTION
Gave The Super Shotgun a 25% Damage Bonus to make up for weak earlygame DPS. This intentionally eats a tick at the upgrade station. Therefore, final stats are the same but $400 cheaper.