### PR TITLE
Bread - adding Cactus Overclocks, minor fixes and buffs

### DIFF
--- a/scripts/population/mvm_boogge_rc3d_adv_night_of_the_living_bread.pop
+++ b/scripts/population/mvm_boogge_rc3d_adv_night_of_the_living_bread.pop
@@ -1,6 +1,7 @@
 #base robot_giant.pop
 #base robot_standard.pop
 #base reverse_timer_text_v3.pop
+#base overclock_cactus_general.pop
 //#base judge_restricts.pop
 
 // Mission by Claudz
@@ -164,8 +165,8 @@ Bread
 			"mod mini-crit airborne" 		0
 			"clip size bonus upgrade" 		2
 			"fire rate bonus" 				0
-			"damage penalty" 				4
-			"projectile lifetime" 			5 // remember to bump this up for bosses
+			"damage penalty" 				3.75
+			"projectile lifetime" 			5.5 // remember to bump this up for bosses
 			"override projectile type" 		13
 			"projectile spread angle mult" 	2
 			"penetrate teammates" 			1
@@ -425,39 +426,8 @@ Bread
             "dmg bonus vs buildings" "1.25"
             "mult dmg vs npc" 2.5
         }
-        // "sentry_minigun" {
-        //     OriginalItemName "Tomislav"
-        //     //"sniper fires tracer" 1
-        //     "spread penalty" "0.3"
-        //     "projectile spread angle penalty" "0.1"
-        //     "weapon spread bonus" 0.1
-        //     //"projectile penetration" 1
-        //     "projectile penetration heavy" "3"
-        //     //"shot penetrate all players" "1"
-        //     // "override projectile type" 13
-        //     //"mult_postfiredelay" "1.2"
-        // }
-        // "Piercing_Sentry"
-        // {
-        //     OriginalItemName "TF_WEAPON_PDA_ENGINEER_BUILD" //Item "Upgradeable TF_WEAPON_PDA_ENGINEER_BUILD"
-        //     "sentry bullet weapon" "sentry_minigun" //"TF_WEAPON_MINIGUN" 
-
-        // }
 
     }
-    // ExtraLoadoutItems
-	// {
-	// 	//AllowEquipOutsideSpawn 1 // Allow equipping items outside spawn
-	// 	Engineer // Player Class
-	// 	{
-	// 		PDA // Extended syntax, Item slot to use
-	// 		{
-	// 			Item  "Piercing_Sentry" // Item name, custom weapon names are available
-	// 			//Cost 100 // The cost of the weapon (default: 0)
-	// 		}
-
-	// 	}
-	// }
 
     ExtendedUpgrades
     {
@@ -2679,7 +2649,7 @@ Bread
                 "spawnflags" "1"
                 "wait" "0.8"
                 "OnTrigger" "!activator,bleedplayer,3,0,-1"
-                "OnTrigger" "!activatorRunScriptCodeself.TakeDamageEx(bread_bite_dmg, activator, null, Vector(), Vector(), 75, 0)0-1"
+                "OnTrigger" "!activatorRunScriptCodeself.TakeDamageEx(bread_bite_dmg, activator, null, Vector(), Vector(), 90, 0)0-1"
                 "OnTrigger" "!activator,$PlaySoundToSelf,=30|weapons\cleaver_hit_03.wav,0,-1"
                 "filtername" "filter_is_red_not_ubered"
                 "StartDisabled" "1"
@@ -3435,7 +3405,7 @@ Bread
                 "filtername" "filter_is_player"
                 "OnStartTouch" "!activatorRunScriptCodeself.ApplyAbsVelocityImpulse(Vector(0,0,700))0.1-1"
                 "OnStartTouch" "!activatorRunScriptCodeself.EmitSound(`General.banana_slip`)0.1-1"
-                "OnStartTouch" "!activatorRunScriptCodeself.TakeDamage(65,1,self)0.1-1"
+                "OnStartTouch" "!activatorRunScriptCodeself.TakeDamage(75,1,self)0.1-1"
 
                 "wait" "0.1"
                 "StartDisabled" "1"
@@ -5699,7 +5669,7 @@ Bread
                 "projectile speed decreased" 0.5 // 0.4
                 "fire rate bonus" 0.3
                 "attach particle effect" 250
-                "fire rate penalty" 4
+                "fire rate penalty" 3
                 "mod projectile heat aim time" 0.2
                 "mod projectile heat no predict target speed" 1
                 "mod projectile heat aim start time" 0.50
@@ -6055,6 +6025,7 @@ Bread
                 "fire rate bonus" 0.2
                 "faster reload rate" 0.3
                 "cancel falling damage" 1
+                "move speed bonus"	0.6
             }
             ItemAttributes
             {
@@ -6267,7 +6238,7 @@ Bread
         RunForThisManyWaves 1
         CooldownTime        40
         DesiredCount        2
-        InitialCooldown     100
+        InitialCooldown     60
         TFBot
         {
             Template T_TFBot_Spy_Bread
@@ -6282,7 +6253,7 @@ Bread
         Where               spawnbot_mission_spy
         BeginAtWave         2
         RunForThisManyWaves 1
-        CooldownTime        70
+        CooldownTime        60
         DesiredCount        1
         InitialCooldown     80
     
@@ -6523,6 +6494,7 @@ Bread
             Name "w1b1"
             WaitforAllDead "w1a1"
             Where spawnbot
+            Where spawnbot_flank
             TotalCount 25
             MaxActive 5
             SpawnCount 5
@@ -6619,7 +6591,7 @@ Bread
             MaxActive 3
             SpawnCount 3
             WaitBeforeStarting 12
-            WaitBetweenSpawns 11
+            WaitBetweenSpawns 8
             TotalCurrency 25
             RandomChoice
             {
@@ -6652,7 +6624,7 @@ Bread
             MaxActive 6
             SpawnCount 3
             WaitBeforeStarting 10
-            WaitBetweenSpawns 18
+            WaitBetweenSpawns 11
             TotalCurrency 50
             TFBot
             {
@@ -7036,10 +7008,10 @@ Bread
             TotalCount 1
             MaxActive 1
             SpawnCount 1
-            WaitBeforeStarting 12
+            WaitBeforeStarting 17
             WaitBetweenSpawns 0
             TotalCurrency 150
-            FirstSpawnWarningSound mvm\giant_heavy\giant_heavy_entrance.wav
+            
 
             TFBot
             {
@@ -7058,6 +7030,7 @@ Bread
             WaitBeforeStarting 12
             WaitBetweenSpawns 0
             TotalCurrency 150
+            FirstSpawnWarningSound mvm\giant_heavy\giant_heavy_entrance.wav
             // FirstSpawnOutput                                                                                                                                                            
 			// {
 			// 	 Target gamerules                                            
@@ -7232,14 +7205,10 @@ Bread
                 }
                 TFBot
                 {
-                    Item "Bread Biter"
-                    //Template T_TFBot_Soldier_Buff_Banner
                     Class Soldier
-                    Name "Buff Soldier"
-                    Skill Normal
-                    ClassIcon soldier_buff
-                    //Attributes SpawnWithFullCharge
-                    Item "The Buff Banner"
+                    Skill Hard
+                    Item "Bread Biter"
+                    Template T_TFBot_Soldier_Buff_Banner
                 }
                 TFBot
                 {
@@ -7313,11 +7282,11 @@ Bread
             Name "w2b1"
             WaitforAllDead "w2a1"
             Where spawnbot_flank
-            TotalCount 9
+            TotalCount 12
             MaxActive 6
             SpawnCount 3
             WaitBeforeStarting 3
-            WaitBetweenSpawns 10
+            WaitBetweenSpawns 9
             TotalCurrency 50
         
             TFBot
@@ -7332,9 +7301,9 @@ Bread
             Name "w2b2"
             WaitForAllSpawned "w2a2"
             Where spawnbot_side
-            TotalCount 6
-            MaxActive 6
-            SpawnCount 3
+            TotalCount 8
+            MaxActive 8
+            SpawnCount 4
             WaitBeforeStarting 25
             WaitBetweenSpawns 15
             TotalCurrency 150
@@ -7372,6 +7341,7 @@ Bread
                 }
                 TFBot { Template T_TFBot_Medic_QuickUber}
                 TFBot { Template T_TFBot_Medic_QuickUber}
+                TFBot { Template T_TFBot_Medic_QuickUber}
             }
         }
         WaveSpawn
@@ -7395,7 +7365,6 @@ Bread
                 MaxVisionRange 1600
                 Item "Bread Biter"
                 //Template T_TFBot_Soldier_Buff_Banner
-                Class Soldier
                 Name "Buff Soldier"
                 Skill Normal
                 ClassIcon soldier_buff
@@ -7677,11 +7646,11 @@ Bread
             WaitForAllDead "w2d1"
             Where spawnbot_flank
             Randomspawn 1
-            TotalCount 15
+            TotalCount 25
             MaxActive 5
             SpawnCount 5
             WaitBeforeStarting 5
-            WaitBetweenSpawns 10
+            WaitBetweenSpawns 6
             TotalCurrency 50
             //support limited
             Squad 
@@ -7787,7 +7756,7 @@ Bread
                     {
                         ItemName "TF_WEAPON_MEDIGUN"
                         "ubercharge rate bonus" 6.5
-                        "uber duration bonus" -5
+                        "uber duration bonus" -4
                     }
                     MaxVisionRange 2000
                 }
@@ -7798,7 +7767,7 @@ Bread
                     {
                         ItemName "TF_WEAPON_MEDIGUN"
                         "ubercharge rate bonus" 6.5
-                        "uber duration bonus" -5
+                        "uber duration bonus" -4
                     }
                     MaxVisionRange 2000
                 }
@@ -7809,7 +7778,7 @@ Bread
             Name "w2e2"
             WaitForAllDead "w2d2"
             Where spawnbot_flank
-            TotalCount 9
+            TotalCount 12
             MaxActive 3
             SpawnCount 3
             WaitBeforeStarting 3
@@ -7855,7 +7824,7 @@ Bread
             {
                 Target "gamerules"
                 Action "RunScriptCode"
-                Param "ClientPrint(null, 3, `\x078ff347 Hint: Projectile penetration cuts through the thickness of bread`)"
+                Param "ClientPrint(null, 3, `\x078ff347 Hint: Fire, Explosions, and Projectile Penetration cuts through the thickness of bread`)"
             }
 		} //
         WaveSpawn // Dummy
@@ -7906,7 +7875,7 @@ Bread
             FirstSpawnWarningSound "vo\mvm_get_to_upgrade01.mp3"
             FirstSpawnOutput
             {
-                Target "spawnbot_mission_spy"
+                Target "spawnbot_mission_temp" //"spawnbot_mission_spy"
                 Action "Disable"
             }
         }
@@ -7916,11 +7885,11 @@ Bread
 			WaitForAllDead "w2e2"
 			WaitBeforeStarting 50
             FirstSpawnWarningSound misc/halloween/clock_tick.wav
-            FirstSpawnOutput
-            {
-                Target "spawnbot_mission_temp"
-                Action "Disable"
-            }
+            // FirstSpawnOutput
+            // {
+            //     Target "spawnbot_mission_temp"
+            //     Action "Disable"
+            // }
 		}
         WaveSpawn
 		{

--- a/scripts/vscripts/bread_logic.nut
+++ b/scripts/vscripts/bread_logic.nut
@@ -102,7 +102,7 @@ if(!("breadeventslol" in getroottable())){
                     if(dbug) PopExtUtil.PrintTable(params)
                     local hits = Bread.GetSentryTrace(params.inflictor, params.damage_position)
                     local owner = params.attacker
-                    if(ent.GetName().find("crate")!= null || ent == Bread.breadboss) {ent.TakeDamageEx(owner, owner, params.weapon, params.damage_force, params.damage_position, params.damage*0.3, 2)}
+                    if(ent.GetName().find("crate")!= null || ent == Bread.breadboss) {ent.TakeDamageEx(owner, owner, params.weapon, params.damage_force, params.damage_position, params.damage*0.45, 2)}
 
                     if(hits != null) {
                         //local dmgBonus = self.GetAttribute("damage bonus",1)
@@ -161,15 +161,6 @@ if(!("breadeventslol" in getroottable())){
                 }
 
             }
-            if( ent.GetClassname() == "obj_sentry") { //ent.GetClassname() == "prop_dynamic" ||
-                if(dbug) PopExtUtil.PrintTable(params)
-                if(params.attacker.GetTeam()!=2) {
-                    params.damage = 0
-                    return
-                }
-
-
-            }
             if(ent.GetClassname() == "base_boss") {
                 //PopExtUtil.PrintTable(params)
                 if(params.attacker.GetTeam()!=2) {
@@ -189,14 +180,39 @@ if(!("breadeventslol" in getroottable())){
                 // if(dbug) ClientPrint(null, 3, "backfire " + backfire.tostring())
                 if(dbug) ClientPrint(null, 3, "pene " + params.weapon.GetAttribute("projectile penetration",0).tostring())
 
-                if(ent.GetName().find("tentacleboss")== null) {
+                // non-tentacles
+                if(ent.GetName().find("tentacleboss") == null) {
                     if( params.weapon.GetClassname().find("minigun")!=null ){
                         //ClientPrint(null, 3, "pls nerf")
-                        params.damage = params.damage * (0.9 + 0.1*params.weapon.GetAttribute("projectile penetration heavy",0))
-                        //ClientPrint(null, 3, "pene " + params.weapon.GetAttribute("projectile penetration heavy",0).tostring())
+                        //params.damage = params.damage * (0.9 + 0.1*params.weapon.GetAttribute("projectile penetration heavy",0))
+                        params.damage = params.damage * 0.85
 
                     } else if (params.weapon.GetClassname().find("flamethrower")!=null || params.weapon.GetClassname().find("tf_weapon_rocketlauncher_fireball")!=null) {
-                        params.damage = params.damage * 0.69
+                        params.damage = params.damage * 0.65
+                    }
+                                    // bow with penetration is way too strong, need to nerf
+                    else if(params.weapon.GetClassname().find("bow")!=null && params.weapon.GetAttribute("projectile penetration",0) > 0){
+                        //ClientPrint(null, 3, "pls nerf")
+                        params.damage = params.damage * 0.75
+                    }
+                    // Explosive damage needs to be nerfed slightly, because of the multiple hitbox mechanic
+                    else if(params.attacker.GetClassname() == "player" && (params.damage_type & Constants.FDmgType.DMG_BLAST) && params.attacker.GetPlayerClass() == Constants.ETFClass.TF_CLASS_DEMOMAN){
+                        //ClientPrint(null, 3, "pls nerf")
+                        params.damage = params.damage * 0.70
+                    }
+                    else if(params.attacker.GetClassname() == "player" && (params.damage_type & Constants.FDmgType.DMG_BLAST) && params.attacker.GetPlayerClass() == Constants.ETFClass.TF_CLASS_SOLDIER){
+                        //ClientPrint(null, 3, "pls nerf")
+                        if(params.weapon.GetAttribute("can overload", -1) > 0)
+                            params.damage = params.damage * 0.70
+                        else
+                            params.damage = params.damage * 0.85
+                    }
+                    // For Cactus Overclocks
+                    if(params.weapon.GetAttribute("mult dmg vs tanks", -99) > -99) {
+                        params.damage = params.damage * params.weapon.GetAttribute("mult dmg vs tanks", 0)
+                    }
+                    if(params.attacker.GetPlayerClass() != Constants.ETFClass.TF_CLASS_SPY && (params.damage_type & Constants.FDmgType.DMG_CLUB)) {
+                        params.damage = params.damage * 1.2
                     }
                 }
 
@@ -234,7 +250,7 @@ if(!("breadeventslol" in getroottable())){
                             isCrit = true
                             params.crit_type = 0
                         } else if(params.weapon.GetClassname().find("bow")!=null){
-                            params.damage = params.damage * 0.75
+                            params.damage = params.damage * 0.9
                             if(!(params.damage_type & Constants.FDmgType.DMG_ACID)) params.damage_type += Constants.FDmgType.DMG_ACID
                             params.damage_stats = Constants.ETFDmgCustom.TF_DMG_CUSTOM_HEADSHOT
                             NetProps.SetPropInt(ent, "m_LastHitGroup",1)
@@ -352,23 +368,7 @@ if(!("breadeventslol" in getroottable())){
                     }
                 }
 
-                // bow with penetration is way too strong, need to nerf
-                if(params.weapon.GetClassname().find("bow")!=null && params.weapon.GetAttribute("projectile penetration",0) > 0){
-                    //ClientPrint(null, 3, "pls nerf")
-                    params.damage = params.damage * 0.75
-                }
-                // Explosive damage needs to be nerfed slightly, because of the multiple hitbox mechanic
-                else if(params.attacker.GetClassname() == "player" && (params.damage_type & Constants.FDmgType.DMG_BLAST) && params.attacker.GetPlayerClass() == Constants.ETFClass.TF_CLASS_DEMOMAN){
-                    //ClientPrint(null, 3, "pls nerf")
-                    params.damage = params.damage * 0.70
-                }
-                else if(params.attacker.GetClassname() == "player" && (params.damage_type & Constants.FDmgType.DMG_BLAST) && params.attacker.GetPlayerClass() == Constants.ETFClass.TF_CLASS_SOLDIER){
-                    //ClientPrint(null, 3, "pls nerf")
-                    if(params.weapon.GetAttribute("can overload", -1) > 0)
-                        params.damage = params.damage * 0.70
-                    else
-                        params.damage = params.damage * 0.85
-                }
+
 
                 dmg = params.damage
                 if ((params.damage_type & Constants.FDmgType.DMG_ACID) || ClaudzUtil.IsPlayerCritBoosted(params.attacker)) {
@@ -393,7 +393,7 @@ if(!("breadeventslol" in getroottable())){
                     {
 
                         if(params.attacker.GetClassname() == "player" && params.attacker.GetPlayerClass() == Constants.ETFClass.TF_CLASS_SNIPER ) {
-                            if(params.attacker.InCond(Constants.ETFCond.TF_COND_ZOOMED) && (params.damage_type & Constants.FDmgType.DMG_BULLET)) {
+                            if((params.attacker.InCond(Constants.ETFCond.TF_COND_ZOOMED) || params.weapon.GetAttribute("revolver use hit locations", 0) == 1) && (params.damage_type & Constants.FDmgType.DMG_BULLET)) {
                                 params.damage = params.damage * 0.5
                                 if(!(params.damage_type & Constants.FDmgType.DMG_ACID)) params.damage_type += Constants.FDmgType.DMG_ACID
                                 params.damage_stats = Constants.ETFDmgCustom.TF_DMG_CUSTOM_HEADSHOT
@@ -407,24 +407,23 @@ if(!("breadeventslol" in getroottable())){
                                 params.inflictor.GetScriptScope().penetrations <- params.inflictor.GetScriptScope().rawin("penetrations") ? params.inflictor.GetScriptScope().penetrations + 1.0 : 1.0
                                 if(dbug) ClientPrint(null, 3, "penetrations " + params.inflictor.GetScriptScope().penetrations.tostring())
                                 params.damage = params.damage * 1.0 * (1.0/(params.inflictor.GetScriptScope().penetrations))
-                                if(!(params.damage_type & Constants.FDmgType.DMG_ACID)) params.damage_type += Constants.FDmgType.DMG_ACID
-                                params.damage_stats = Constants.ETFDmgCustom.TF_DMG_CUSTOM_HEADSHOT
-                                NetProps.SetPropInt(ent, "m_LastHitGroup",1)
-                                //ClientPrint(null, 3, params.inflictor.GetClassname())
 
-                                // if(params.inflictor.GetClassname() == "tf_projectile_arrow" && params.attacker.GetPlayerClass() == Constants.ETFClass.TF_CLASS_SNIPER) {
-                                //     params.inflictor.GetScriptScope().penetrations <- params.inflictor.GetScriptScope().rawin("penetrations") ? params.inflictor.GetScriptScope().penetrations +1 : 1
-                                //     EntFireByHandle(params.inflictor, "kill", null, -1, null, null)
-                                // }
-                                isCrit = true
-                                params.crit_type = 0
-                                dmg = params.damage*3
+                                if(params.weapon.GetAttribute("cannot headshot", 0) != 1) {
+                                    if(!(params.damage_type & Constants.FDmgType.DMG_ACID)) params.damage_type += Constants.FDmgType.DMG_ACID
+                                    params.damage_stats = Constants.ETFDmgCustom.TF_DMG_CUSTOM_HEADSHOT
+
+                                    NetProps.SetPropInt(ent, "m_LastHitGroup",1)
+                                    params.crit_type = 0
+                                    isCrit = true
+                                    dmg = params.damage*3
+                                }
+
                             }
                         }
 
                         else if(params.attacker.GetClassname() == "player" && params.attacker.GetPlayerClass() == Constants.ETFClass.TF_CLASS_SPY ) {
                             if(params.damage_type & Constants.FDmgType.DMG_BULLET) {
-                                params.damage = params.damage * 2.0
+                                params.damage = params.damage * 1.25
                                 if(!(params.damage_type & Constants.FDmgType.DMG_ACID)) params.damage_type += Constants.FDmgType.DMG_ACID
                                 params.damage_stats = Constants.ETFDmgCustom.TF_DMG_CUSTOM_HEADSHOT
                                 NetProps.SetPropInt(ent, "m_LastHitGroup",1)
@@ -463,7 +462,7 @@ if(!("breadeventslol" in getroottable())){
                     if(dis.Length() < 50 || disOrigin.Length() < 70)
                     {
                         if(params.attacker.GetClassname() == "player" && params.attacker.GetPlayerClass() == Constants.ETFClass.TF_CLASS_SNIPER ) {
-                            if(params.attacker.InCond(Constants.ETFCond.TF_COND_ZOOMED) && (params.damage_type & Constants.FDmgType.DMG_BULLET)) {
+                            if((params.attacker.InCond(Constants.ETFCond.TF_COND_ZOOMED) || params.weapon.GetAttribute("revolver use hit locations", 0) == 1) && (params.damage_type & Constants.FDmgType.DMG_BULLET)) {
                                 params.damage = params.damage * 0.5
                                 if(!(params.damage_type & Constants.FDmgType.DMG_ACID)) params.damage_type += Constants.FDmgType.DMG_ACID
                                 params.damage_stats = Constants.ETFDmgCustom.TF_DMG_CUSTOM_HEADSHOT
@@ -471,22 +470,28 @@ if(!("breadeventslol" in getroottable())){
                                 isCrit = true
                                 dmg = params.damage*3
                             }
-                            else if(params.weapon.GetClassname().find("bow")!=null){
+                            else if(params.weapon.GetClassname().find("bow")!=null ){
                                 params.inflictor.ValidateScriptScope()
                                 params.inflictor.GetScriptScope().penetrations <- params.inflictor.GetScriptScope().rawin("penetrations") ? params.inflictor.GetScriptScope().penetrations +1 : 1
                                 params.damage = params.damage * 1.0 * (1/(params.inflictor.GetScriptScope().penetrations))
-                                if(!(params.damage_type & Constants.FDmgType.DMG_ACID)) params.damage_type += Constants.FDmgType.DMG_ACID
-                                params.damage_stats = Constants.ETFDmgCustom.TF_DMG_CUSTOM_HEADSHOT
-                                EntFireByHandle(params.inflictor, "kill", null, -1, null, null)
-                                NetProps.SetPropInt(ent, "m_LastHitGroup",1)
-                                isCrit = true
-                                dmg = params.damage*3
+
+                                if(params.weapon.GetAttribute("cannot headshot", 0) != 1) {
+                                    if(!(params.damage_type & Constants.FDmgType.DMG_ACID)) params.damage_type += Constants.FDmgType.DMG_ACID
+                                    params.damage_stats = Constants.ETFDmgCustom.TF_DMG_CUSTOM_HEADSHOT
+                                    EntFireByHandle(params.inflictor, "kill", null, -1, null, null)
+
+                                    NetProps.SetPropInt(ent, "m_LastHitGroup",1)
+                                    isCrit = true
+                                    dmg = params.damage*3
+                                }
+
+
                             }
                         }
 
                         else if(params.attacker.GetClassname() == "player" && params.attacker.GetPlayerClass() == Constants.ETFClass.TF_CLASS_SPY ) {
                             if(params.damage_type & Constants.FDmgType.DMG_BULLET) {
-                                params.damage = params.damage * 2
+                                params.damage = params.damage * 1.25
                                 if(!(params.damage_type & Constants.FDmgType.DMG_ACID)) params.damage_type += Constants.FDmgType.DMG_ACID
                                 params.damage_stats = Constants.ETFDmgCustom.TF_DMG_CUSTOM_HEADSHOT
                                 NetProps.SetPropInt(ent, "m_LastHitGroup",1)
@@ -526,18 +531,20 @@ if(!("breadeventslol" in getroottable())){
                 if(params.damage_stats == Constants.ETFDmgCustom.TF_DMG_CUSTOM_HEADSHOT && params.weapon.GetAttribute("explosive sniper shot",-1) > -1) {
                     local flDmgRange = 125 + params.weapon.GetAttribute("explosive sniper shot",-1) * 25;
                     local flDmg = 100 + params.weapon.GetAttribute("explosive sniper shot",-1) * 20; //in game the dmg starts at 130, not 100
+                    local expMult = params.weapon.GetAttribute("mult bleeding dmg",1);
+                    flDmg *= expMult
                     local xEnt = null
                     while ( xEnt = Entities.FindByClassnameWithin(xEnt, "base_boss", params.damage_position, flDmgRange))
                     {
                         xEnt.TakeDamageEx(params.attacker, params.attacker, params.weapon, Vector(0,0,0), params.damage_position, flDmg*0.75, 64)
-                        Bread.EmitFx(xEnt,"Weapon_Upgrade.ExplosiveHeadshot",0.6)
+                        if(self.GetClassname().find("sniperrifle") != null) Bread.EmitFx(xEnt,"Weapon_Upgrade.ExplosiveHeadshot",0.6)
                     }
                     xEnt = null
                     while ( xEnt = Entities.FindByClassnameWithin(xEnt, "player", params.damage_position, flDmgRange))
                     {
                         if(xEnt.GetTeam()!=2) {
                             xEnt.TakeDamageEx(params.attacker, params.attacker, params.weapon, Vector(0,0,0), params.damage_position, flDmg, 64)
-                            Bread.EmitFx(xEnt,"Weapon_Upgrade.ExplosiveHeadshot",0.6)
+                            if(self.GetClassname().find("sniperrifle") != null) Bread.EmitFx(xEnt,"Weapon_Upgrade.ExplosiveHeadshot",0.6)
                         }
                     }
                 }
@@ -580,10 +587,23 @@ Bread.PlayerSetup <- function(player) {
         if (weapon == null || weapon.IsMeleeWeapon())
             continue
 
+        // need to exclude bow, crossbow, rescue ranger
+        if(!(weapon.GetAttribute("projectile penetration",0) > 0 || weapon.GetAttribute("projectile penetration heavy",0) > 0 ) || weapon.GetClassname().find("bow")!=null || weapon.GetClassname().find("building_rescue")!=null) {
+            continue
+        }
+
+        //ClientPrint(null,3,weapon.GetClassname())
+
+        local bDmg = weapon.GetClassname().find("shotgun") != null ? 30 : 3
+        if(weapon.GetClassname().find("pistol") != null || weapon.GetClassname().find("handgun_scout_secondary") != null) bDmg = 7
+        if(weapon.GetClassname().find("scattergun") != null || weapon.GetClassname().find("soda_popper") != null || weapon.GetClassname().find("brawler_blaster") != null) bDmg = 30
+        if(weapon.GetClassname().find("revolver") != null|| weapon.GetClassname().find("handgun_scout_primary") != null) bDmg = 15
+
         weapon.ValidateScriptScope()
         weapon.GetScriptScope().last_fire_time <- 0.0
         weapon.GetScriptScope().last_charge_amt <- 0.0
         weapon.GetScriptScope().charges <- [0]
+        weapon.GetScriptScope().baseDmg <- bDmg
 
         weapon.GetScriptScope().BreadCheckWeaponFire <- BreadCheckWeaponFire
         EntFireByHandle(weapon, "RunScriptCode", "PopExtUtil.AddThinkToEnt(self, `BreadCheckWeaponFire`)", 1, null, null)
@@ -601,9 +621,9 @@ Bread.PlayerSetup <- function(player) {
         if(owner.GetActiveWeapon()!=self) return
         else if(dbug) ClientPrint(null,4,"thinktest" + Time().tostring())
 
-        if(owner.GetPlayerClass() == Constants.ETFClass.TF_CLASS_SNIPER){
-            if(dbug) ClientPrint(null,3,"im here " + self.GetClassname()+ " " + self.GetAttribute("projectile penetration",0).tostring())
-            if(self.GetClassname().find("sniperrifle") != null && self.GetAttribute("projectile penetration",0) > 0){
+        if(owner.GetPlayerClass() == Constants.ETFClass.TF_CLASS_SNIPER && self.GetClassname().find("sniperrifle") != null){
+            //if(dbug) ClientPrint(null,3,"im here " + self.GetClassname()+ " " + self.GetAttribute("projectile penetration",0).tostring())
+            if(self.GetAttribute("projectile penetration",0) > 0){
                 local hits = Bread.GetPlayerTraceBoss(self)
                 if(hits != null) {
                     local dmgBonus = self.GetAttribute("damage bonus",1)
@@ -615,7 +635,40 @@ Bread.PlayerSetup <- function(player) {
                         //TakeDamageEx(handle hInflictor, handle hAttacker, handle hWeapon, Vector vecDamageForce, Vector vecDamagePosition, float flDamage, int nDamageType)
                     }
                 }
+            }
+        }
 
+        else if(self.GetAttribute("projectile penetration",0) > 0){
+            local hits = Bread.GetPlayerTraceBoss(self)
+
+            local bDmg = baseDmg
+            if(hits != null) {
+                local dmgBonus = self.GetAttribute("damage bonus",1)
+                foreach (i, hit in hits)
+                {
+                    local falloff = 1.0 - ((ClaudzUtil.Min((owner.GetOrigin()-hit.enthit.GetOrigin()).Length(), 1500.0))/1500.0)
+                    local rampup = bDmg * falloff
+                    hit.enthit.TakeDamageEx(owner, owner, owner.GetActiveWeapon(), Vector(0,0,0), hit.pos, (bDmg + rampup)*dmgBonus, 2)
+                    //TakeDamageEx(handle hInflictor, handle hAttacker, handle hWeapon, Vector vecDamageForce, Vector vecDamagePosition, float flDamage, int nDamageType)
+                }
+            }
+        }
+
+        else if (self.GetAttribute("projectile penetration heavy",0) > 0){
+            local hits = Bread.GetPlayerTraceBoss(self)
+            local max = self.GetAttribute("projectile penetration heavy",0)
+            if(hits != null) {
+                local dmgBonus = self.GetAttribute("damage bonus",1)
+                local bDmg = baseDmg
+                foreach (i, hit in hits)
+                {
+                    local falloff = 1.0 - ((ClaudzUtil.Min((owner.GetOrigin()-hit.enthit.GetOrigin()).Length(), 1500.0))/1500.0)
+                    //ClientPrint(null,3,"falloff" + falloff.tostring() + " len " + (owner.GetOrigin()-hit.enthit.GetOrigin()).Length().tostring())
+                    local rampup = bDmg * falloff
+                    hit.enthit.TakeDamageEx(owner, owner, owner.GetActiveWeapon(), Vector(0,0,0), hit.pos, (baseDmg + rampup)*dmgBonus, 2)
+                    if(i == max) break
+                    //TakeDamageEx(handle hInflictor, handle hAttacker, handle hWeapon, Vector vecDamageForce, Vector vecDamagePosition, float flDamage, int nDamageType)
+                }
             }
         }
 
@@ -947,7 +1000,7 @@ Bread.Hints <- function() {
         if (player = PlayerInstanceFromIndex(i), player && player.GetTeam() == 2)
         {
             if(player.GetPlayerClass() == Constants.ETFClass.TF_CLASS_SNIPER)
-                ClientPrint(player, 3, "\x078ff347 Hint: Try aiming for the tentacles or headshot the center of the boss' forehead")
+                ClientPrint(player, 3, "\x078ff347 Hint: While zoomed, try aiming for the tentacles or the center of the boss' forehead")
         }
     }
 }


### PR DESCRIPTION
Misc
- Added Cactus Overclocks

W1
- give w1 cannon demos a chance to spawn from the flank spawn
- G Acid Rain Huntsman: increase health 3k -> 3.5k; decrease fire rate penalty 4 -> 3;
- Add 5 sec delay between the giant BB soldiers

W2
- add one more uber med per g shotgun heavy
- engi cd 70 -> 60
- spy initial cd 100 -> 60
- Very Quick Uber Medic uber duration 3 -> 4

Boss
- Boss takes +20% dmg from non-spy melee
- Bite Dmg increased 75 -> 90
- Tentacle Ground Burst Dmg increased 65 -> 75
- Fixed bug where Projectile Penetration was not working for hitscan
  - because of this, nerf minigun dmg by 15%