### PR TITLE
Update Night of the Living Bread

### DIFF
--- a/scripts/population/mvm_boogge_rc3d_adv_night_of_the_living_bread.pop
+++ b/scripts/population/mvm_boogge_rc3d_adv_night_of_the_living_bread.pop
@@ -275,7 +275,7 @@ Bread
             OriginalItemName "tf_weapon_rocketlauncher"
             "add damage type" 128
 			"remove damage type" 64
-            "damage bonus" 0.4
+            "damage bonus" 0.35
             "projectile gravity" 999
             "Projectile speed increased" 0.3
             "projectile spread angle penalty" 0 //3
@@ -302,7 +302,7 @@ Bread
             OriginalItemName "tf_weapon_rocketlauncher"
             "add damage type" 128
 			"remove damage type" 64
-            "damage bonus" 0.8
+            "damage bonus" 0.75
             "projectile gravity" 999
             "Projectile speed increased" 0.2
             "projectile spread angle penalty" 0 //3
@@ -5675,7 +5675,7 @@ Bread
                 "projectile speed decreased" 0.5 // 0.4
                 "fire rate bonus" 0.3
                 "attach particle effect" 250
-                "fire rate penalty" 3
+                "fire rate penalty" 3.3
                 "mod projectile heat aim time" 0.2
                 "mod projectile heat no predict target speed" 1
                 "mod projectile heat aim start time" 0.50
@@ -5855,7 +5855,7 @@ Bread
 			{
 				ItemName "The Bread Bite"
 				"mod_maxhealth_drain_rate" 0
-                "move speed bonus" 0.85
+                "move speed bonus" 0.75
 			}
             ItemAttributes
             {
@@ -6434,9 +6434,9 @@ Bread
             Name "w1a1"
             WaitforAllDead "w1c2"
             Where spawnbot
-            TotalCount 15
-            MaxActive 5
-            SpawnCount 5
+            TotalCount 12
+            MaxActive 4
+            SpawnCount 4
             WaitBeforeStarting 10
             WaitBetweenSpawns 10
             TotalCurrency 50
@@ -6466,12 +6466,15 @@ Bread
                     Template T_TFBot_Pyro_Backburner
                     MoveBehindEnemy 1
                     Tag bot_flank
+                    Action Mobber
+
                 }  
                 TFBot
                 {
                     Template T_TFBot_Pyro_Backburner
                     MoveBehindEnemy 1
                     Tag bot_flank
+                    Action Mobber
                     Attributes AlwaysFireWeapon
                 }  
             }
@@ -6536,12 +6539,12 @@ Bread
         WaveSpawn
         {
             Name "w1b2"
-            waitforallspawned "w1a1"
+            WaitForAllDead "w1a1"
             Where spawnbot_side
             TotalCount 4
             MaxActive 2
             SpawnCount 1
-            WaitBeforeStarting 12
+            WaitBeforeStarting 6
             WaitBetweenSpawns 15
             TotalCurrency 50
         
@@ -6718,7 +6721,7 @@ Bread
         WaveSpawn
         {
             Name "w1es"
-            WaitForAllSpawned "w1b2"
+            WaitForAllSpawned "w1a1"
             Where spawnbot_void1
             Where spawnbot_void2
             Where spawnbot_void3
@@ -6974,8 +6977,8 @@ Bread
             WaitForAllDead "w1d2"
             Where spawnbot_invasion
             TotalCount 16
-            MaxActive 8
-            SpawnCount 4
+            MaxActive 6
+            SpawnCount 3
             WaitBeforeStarting 8
             WaitBetweenSpawns 17
             TotalCurrency 25
@@ -7070,8 +7073,8 @@ Bread
             WaitForAllSpawned "w1e1b"
             Where spawnbot_invasion
             TotalCount 20
-            MaxActive 4
-            SpawnCount 4
+            MaxActive 2
+            SpawnCount 2
             WaitBeforeStarting 8
             WaitBetweenSpawns 15
             TotalCurrency 0
@@ -7164,6 +7167,10 @@ Bread
                         //EntFire(`tf_gamerules`, `PlayVO`, `vo/announcer_ends_60sec.mp3`, 0, null)
                         EntFire(`music_phase3`, `PlaySound`, null, 0, null)
                     }
+                    `30` : function()
+                    {
+                        Bread.DesperateTimes()
+                    }
                 })
             "
         }
@@ -7188,25 +7195,27 @@ Bread
                 NoFormation 1
                 TFBot
                 {
-                    Item "Bread Biter"
-                    //Template T_TFBot_Soldier_Buff_Banner
                     Class Soldier
-                    Name "Buff Soldier"
                     Skill Normal
-                    ClassIcon soldier_buff
-                    //Attributes SpawnWithFullCharge
-                    Item "The Buff Banner"
+                    Item "Bread Biter"
+                    Template T_TFBot_Soldier_Buff_Banner
+                    MaxVisionRange 1600
+                    CharacterAttributes
+                    {
+                        "increase buff duration"	2.0
+                    }
                 }
                 TFBot
                 {
-                    Item "Bread Biter"
-                    //Template T_TFBot_Soldier_Buff_Banner
                     Class Soldier
-                    Name "Buff Soldier"
                     Skill Normal
-                    ClassIcon soldier_buff
-                    //Attributes SpawnWithFullCharge
-                    Item "The Buff Banner"
+                    Item "Bread Biter"
+                    Template T_TFBot_Soldier_Buff_Banner
+                    MaxVisionRange 1600
+                    CharacterAttributes
+                    {
+                        "increase buff duration"	2.0
+                    }
 
                 }
                 TFBot
@@ -7215,6 +7224,11 @@ Bread
                     Skill Hard
                     Item "Bread Biter"
                     Template T_TFBot_Soldier_Buff_Banner
+                    MaxVisionRange 1600
+                    CharacterAttributes
+                    {
+                        "increase buff duration"	2.0
+                    }
                 }
                 TFBot
                 {
@@ -7222,12 +7236,18 @@ Bread
                     Skill Hard
                     Item "Bread Biter"
                     Template T_TFBot_Soldier_Buff_Banner
+                    MaxVisionRange 1600
+                    CharacterAttributes
+                    {
+                        "increase buff duration"	2.0
+                    }
                 }
                 TFBot
                 {
                     Class Pyro
                     ClassIcon 	pyro_reflect
-                    Skill Normal
+                    MaxVisionRange 1600
+                    Skill Hard
                     Item "Bread Biter"
                     Item "Traffic Cone"
                     Name "Reflective Toaster"
@@ -7236,7 +7256,8 @@ Bread
                 {
                     Class Pyro
                     ClassIcon 	pyro_reflect
-                    Skill Normal
+                    MaxVisionRange 1600
+                    Skill Hard
                     Item "Bread Biter"
                     Item "Traffic Cone"
                     Name "Reflective Toaster"
@@ -7365,17 +7386,14 @@ Bread
             TFBot
             {
                 Class Soldier
-                // Skill Hard
-                // Item "Bread Biter"
-                // Template T_TFBot_Soldier_Extended_Buff_Banner
-                MaxVisionRange 1600
-                Item "Bread Biter"
-                //Template T_TFBot_Soldier_Buff_Banner
-                Name "Buff Soldier"
                 Skill Normal
-                ClassIcon soldier_buff
-                Attributes SpawnWithFullCharge
-                Item "The Buff Banner"
+                Item "Bread Biter"
+                Template T_TFBot_Soldier_Buff_Banner
+                MaxVisionRange 1600
+                CharacterAttributes
+                {
+                    "increase buff duration"	2.0
+                }
             }
         }
         WaveSpawn
@@ -7687,11 +7705,13 @@ Bread
                 {
                     Template    T_TFBot_Scout_Cleaver
                     ClassIcon Scout
+                    MaxVisionRange 1600
                 }
                 TFBot
                 {
                     Template    T_TFBot_Scout_Cleaver
                     ClassIcon Scout
+                    MaxVisionRange 1600
                 }
             }  
         }
@@ -8047,7 +8067,7 @@ Bread
             MaxActive 4
             SpawnCount 4
             WaitBeforeStarting 35
-            WaitBetweenSpawns 11
+            WaitBetweenSpawns 12
             TotalCurrency 25
             //Support Limited
             TFBot
@@ -8056,6 +8076,7 @@ Bread
                 Skill Hard
                 Item "Bread Biter"
                 Action Mobber
+                MaxVisionRange 1600
             }
         }
         WaveSpawn
@@ -8067,7 +8088,7 @@ Bread
             MaxActive 2
             SpawnCount 1
             WaitBeforeStarting 8
-            WaitBetweenSpawns 18
+            WaitBetweenSpawns 20
             TotalCurrency 150
             Support 1
             RandomChoice {
@@ -8335,7 +8356,7 @@ Bread
                 Class Pyro
                 Name "bready bye"
                 Skill Expert
-                Health 1200
+                Health 1500
                 UseBestWeapon 1
                 Scale 1.5
                 //WeaponRestrictions PrimaryOnly
@@ -8387,7 +8408,7 @@ Bread
             MaxActive 4
             SpawnCount 2
             WaitBeforeStarting 97
-            WaitBetweenSpawns 11
+            WaitBetweenSpawns 12
             TotalCurrency 125
             Support 1
             RandomChoice
@@ -8433,7 +8454,7 @@ Bread
             MaxActive 4
             SpawnCount 2
             WaitBeforeStarting 105
-            WaitBetweenSpawns 15
+            WaitBetweenSpawns 16
             TotalCurrency 125
             Support 1
             RandomChoice

--- a/scripts/vscripts/bread_logic.nut
+++ b/scripts/vscripts/bread_logic.nut
@@ -96,7 +96,7 @@ if(!("breadeventslol" in getroottable())){
                     if(dbug) PopExtUtil.PrintTable(params)
                     local hits = Bread.GetSentryTrace(params.inflictor, params.damage_position)
                     local owner = params.attacker
-                    if(ent.GetName().find("crate")!= null || ent == Bread.breadboss) {ent.TakeDamageEx(owner, owner, params.weapon, params.damage_force, params.damage_position, params.damage*0.45, 2)}
+                    if(ent.GetName().find("crate")!= null || ent == Bread.breadboss) {ent.TakeDamageEx(owner, owner, params.weapon, params.damage_force, params.damage_position, params.damage*0.55, 2)}
 
                     if(hits != null) {
                         //local dmgBonus = self.GetAttribute("damage bonus",1)
@@ -111,7 +111,7 @@ if(!("breadeventslol" in getroottable())){
                         }
                     }
                 } else if (params.inflictor.GetClassname() == "obj_sentrygun" && params.attacker.GetTeam()==2){
-                    if(ent.GetName().find("crate")!= null || ent == Bread.breadboss) params.damage = params.damage*1.3
+                    if(ent.GetName().find("crate")!= null || ent == Bread.breadboss) params.damage = params.damage*1.4
                 }
             } catch (exception){
 
@@ -160,6 +160,8 @@ if(!("breadeventslol" in getroottable())){
                 if(params.attacker.GetTeam()!=2) {
                     params.damage = 0
                     return
+                } else if (Bread.desperation == true) {
+                    params.damage = params.damage * 1.25
                 }
                 // if(params.attacker.GetClassname().find("sentrygun")!=null) {
                 //     params.attacker = params.attacker.GetOwner()
@@ -182,7 +184,7 @@ if(!("breadeventslol" in getroottable())){
                         params.damage = params.damage * 0.85
 
                     } else if (params.weapon.GetClassname().find("flamethrower")!=null || params.weapon.GetClassname().find("tf_weapon_rocketlauncher_fireball")!=null ) {
-                        params.damage = params.damage * 0.65
+                        params.damage = params.damage * 0.69
                     }
                                     // bow with penetration is way too strong, need to nerf
                     else if((params.weapon.GetClassname().find("bow")!=null && params.weapon.GetAttribute("projectile penetration",0) > 0) || params.weapon.GetClassname().find("tf_weapon_raygun")!=null){
@@ -989,6 +991,10 @@ Bread.BreadBossSetup <- function(breadboss) {
     Bread.Hints()
 
 }
+Bread.desperation <- false
+Bread.DesperateTimes <- function() {
+    Bread.desperation = true
+}
 
 Bread.Hints <- function() {
     for (local i = 1, player; i <= MaxClients().tointeger(); i++)
@@ -997,6 +1003,8 @@ Bread.Hints <- function() {
         {
             if(player.GetPlayerClass() == Constants.ETFClass.TF_CLASS_SNIPER)
                 ClientPrint(player, 3, "\x078ff347 Hint: While zoomed, try aiming for the tentacles or the center of the boss' forehead")
+            if(player.GetPlayerClass() == Constants.ETFClass.TF_CLASS_SPY)
+                ClientPrint(player, 3, "\x078ff347 Hint: You can backstab the boss, just watch out for the tentacles")
         }
     }
 }
@@ -1663,7 +1671,7 @@ Bread.TentySetSeq <- function(tenty, seq, rate = 1, cycle = 0.0) {
 Bread.TentyUpdateTarget <- function(tenty) {
     local ent = ClaudzUtil.GetClosestTargetLOS(tenty, 1200, 2, tenty)
     tenty.GetScriptScope().curTarget <- ent
-    tenty.GetScriptScope().nextUpdate <- Time() + 3.5
+    tenty.GetScriptScope().nextUpdate <- Time() + 4
 }
 Bread.TentyRotate <- function(tenty) {
     local scope = tenty.GetScriptScope()


### PR DESCRIPTION
W1
- reduced w1 early heavies max active 5 -> 4
- major league scouts are now wait for all dead after g sollies instead of wait for all spawned
- flanking pyros are all mobber instead of having a chance to be mobber
- reduce w1 final support max active slightly

W2
- have buff soldiers have 2.0 increased buff duration
- change early reflect pyros from Normal to Hard
- boost sentry damage to boss slightly
- During the last 30 secs, if players are struggling, give them a small desperate boost in damage